### PR TITLE
Update Documentation + Update Rate -> Update Delay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "ncomm"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ctrlc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ncomm"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Rust Node-Based Communication Prototype Framework"

--- a/examples/minimal_publisher_subscriber/Cargo.lock
+++ b/examples/minimal_publisher_subscriber/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ctrlc",
 ]

--- a/examples/minimal_publisher_subscriber/Cargo.toml
+++ b/examples/minimal_publisher_subscriber/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ncomm = { path = "../../", version = "0.1.2" }
+ncomm = { path = "../../", version = "0.2.0" }

--- a/examples/minimal_publisher_subscriber/src/minimal_publisher.rs
+++ b/examples/minimal_publisher_subscriber/src/minimal_publisher.rs
@@ -27,7 +27,7 @@ impl<'a> MinimalPublisher<'a> {
 impl<'a> Node for MinimalPublisher<'a> {
     fn name(&self) -> String { String::from(self.name) }
 
-    fn get_update_rate(&self) -> u128 { 500u128 }
+    fn get_update_delay(&self) -> u128 { 500u128 }
 
     fn start(&mut self) {
         self.publish_message();

--- a/examples/minimal_publisher_subscriber/src/minimal_subscriber.rs
+++ b/examples/minimal_publisher_subscriber/src/minimal_subscriber.rs
@@ -24,7 +24,7 @@ impl<'a> MinimalSubscriber<'a> {
 impl<'a> Node for MinimalSubscriber<'a> {
     fn name(&self) -> String { String::from(self.name) }
 
-    fn get_update_rate(&self) -> u128 { 500u128 }
+    fn get_update_delay(&self) -> u128 { 500u128 }
 
     fn start(&mut self) {
         self.print_subscriber_data();

--- a/examples/minimal_service_client/Cargo.lock
+++ b/examples/minimal_service_client/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ctrlc",
 ]

--- a/examples/minimal_service_client/Cargo.toml
+++ b/examples/minimal_service_client/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ncomm = { path = "../../", version = "0.1.2" }
+ncomm = { path = "../../", version = "0.2.0" }

--- a/examples/minimal_service_client/src/minimal_client.rs
+++ b/examples/minimal_service_client/src/minimal_client.rs
@@ -17,7 +17,7 @@ impl<'a> MinimalClient<'a> {
 impl<'a> Node for MinimalClient<'a> {
     fn name(&self) -> String { String::from(self.name) }
 
-    fn get_update_rate(&self) -> u128 { 10u128 }
+    fn get_update_delay(&self) -> u128 { 10u128 }
 
     fn start(&mut self) {
         self.client.send_request(AddTwoIntsRequest { a: 10, b: 20}).unwrap();

--- a/examples/minimal_service_client/src/minimal_service.rs
+++ b/examples/minimal_service_client/src/minimal_service.rs
@@ -41,7 +41,7 @@ impl<'a> MinimalService<'a> {
 impl<'a> Node for MinimalService<'a> {
     fn name(&self) -> String { String::from(self.name) }
 
-    fn get_update_rate(&self) -> u128 { 10u128 }
+    fn get_update_delay(&self) -> u128 { 10u128 }
 
     fn start(&mut self) { }
 

--- a/examples/minimal_update_service_client/Cargo.lock
+++ b/examples/minimal_update_service_client/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ctrlc",
 ]

--- a/examples/minimal_update_service_client/Cargo.toml
+++ b/examples/minimal_update_service_client/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ncomm = { path = "../../", version = "0.1.2" }
+ncomm = { path = "../../", version = "0.2.0" }

--- a/examples/minimal_update_service_client/src/fibonacci_update_client.rs
+++ b/examples/minimal_update_service_client/src/fibonacci_update_client.rs
@@ -17,7 +17,7 @@ impl<'a> FibonacciUpdateClient<'a> {
 impl<'a> Node for FibonacciUpdateClient<'a> {
     fn name(&self) -> String { String::from(self.name) }
 
-    fn get_update_rate(&self) -> u128 { 10u128 }
+    fn get_update_delay(&self) -> u128 { 10u128 }
 
     fn start(&mut self) {
         self.update_client.send_request(FibonacciRequest { order: 10 }).unwrap();

--- a/examples/minimal_update_service_client/src/fibonacci_update_server.rs
+++ b/examples/minimal_update_service_client/src/fibonacci_update_server.rs
@@ -39,7 +39,7 @@ impl<'a> FibonacciUpdateServer<'a> {
 impl<'a> Node for FibonacciUpdateServer<'a> {
     fn name(&self) -> String { String::from(self.name) }
 
-    fn get_update_rate(&self) -> u128 { 10u128 }
+    fn get_update_delay(&self) -> u128 { 10u128 }
 
     fn start(&mut self) {}
 

--- a/src/client_server.rs
+++ b/src/client_server.rs
@@ -1,3 +1,10 @@
+//!
+//! Client - Server Communication
+//! 
+//! The idea here is that over time a large number of ways for clients to communicate
+//! with servers should implement the Client and Server Traits.
+//! 
+
 pub mod local;
 
 use std::error::Error;

--- a/src/client_server/local.rs
+++ b/src/client_server/local.rs
@@ -64,6 +64,13 @@ impl<Req: PartialEq + Send + Clone,
 }
 
 impl<Req: PartialEq + Send + Clone,
+     Res: PartialEq + Send + Clone> Default for LocalServer<Req, Res> {
+        fn default() -> Self {
+            Self::new()
+        }
+     }
+
+impl<Req: PartialEq + Send + Clone,
     Res: PartialEq + Send + Clone> Client<Req, Res, mpsc::SendError<Req>> for LocalClient<Req, Res> {
     fn send_request(&self, request: Req) -> Result<(), mpsc::SendError<Req>> {
         self.req_tx.send(request)
@@ -75,7 +82,7 @@ impl<Req: PartialEq + Send + Clone,
         if let Some(response) = iter.last() {
             return Some(response);
         }
-        return None;
+        None
     }
 }
 
@@ -90,7 +97,7 @@ impl<Req: PartialEq + Send + Clone,
         let channels = LocalServerChannels::new(req_rx, res_tx);
         self.client_mappings.insert(client_name, channels);
 
-        return LocalClient::new(req_tx, res_rx);
+        LocalClient::new(req_tx, res_rx)
     }
 
     fn get_clients(&self) -> Vec<String> {
@@ -100,7 +107,7 @@ impl<Req: PartialEq + Send + Clone,
             clients.push(client.clone());
         }
 
-        return clients;
+        clients
     }
 
     fn receive_requests(&self) -> Vec<(String, Req)> {
@@ -113,18 +120,18 @@ impl<Req: PartialEq + Send + Clone,
             }
         }
 
-        return requests;
+        requests
     }
 
     fn send_response(&self, client: String, response: Res) -> SendError<Res> {
         if let Some(channels) = self.client_mappings.get(&client) {
             if let Err(send_err) = channels.res_tx.send(response) {
-                return SendError::<Res>::SendIncomplete((client, send_err));
+                SendError::<Res>::SendIncomplete((client, send_err))
             } else {
-                return SendError::<Res>::NoError(client);
+                SendError::<Res>::NoError(client)
             }
         } else {
-            return SendError::<Res>::ClientNotFound(client);
+            SendError::<Res>::ClientNotFound(client)
         }
     }
 
@@ -143,7 +150,7 @@ impl<Req: PartialEq + Send + Clone,
             }
         }
 
-        return errors;
+        errors
     }
 }
 

--- a/src/client_server/local.rs
+++ b/src/client_server/local.rs
@@ -1,8 +1,16 @@
-use std::{sync::{mpsc, mpsc::{Sender, Receiver}}};
+//!
+//! A local mpsc channel-based Client + Server.
+//! 
+//! The Local Client + Server sends data along a mpsc channel from the client
+//! to the server and back to the client.
+//! 
+
+use std::sync::{mpsc, mpsc::{Sender, Receiver}};
 use std::collections::HashMap;
 
 use crate::client_server::{Client, Server};
 
+/// Error from sending data along the local client + server.
 #[derive(PartialEq, Debug)]
 pub enum SendError<T> {
     NoError(String),
@@ -10,18 +18,22 @@ pub enum SendError<T> {
     SendIncomplete((String, mpsc::SendError<T>)),
 }
 
+/// A Local Client that sends data to a Local Server.
 pub struct LocalClient<Req: PartialEq + Send + Clone,
                        Res: PartialEq + Send + Clone> {
     req_tx: Sender<Req>,
     res_rx: Receiver<Res>
 }
 
+/// A Singular Channel from a Local Client to the Local Server.
 struct LocalServerChannels<Req: PartialEq + Send + Clone,
                            Res: PartialEq + Send + Clone> {
     req_rx: Receiver<Req>,
     res_tx: Sender<Res>,
 }
 
+/// A Local Server receives data from a client (of many) processes the data
+/// and sends a response back to the client.
 pub struct LocalServer<Req: PartialEq + Send + Clone,
                        Res: PartialEq + Send + Clone> {
     client_mappings: HashMap<String, LocalServerChannels<Req, Res>>,
@@ -29,6 +41,7 @@ pub struct LocalServer<Req: PartialEq + Send + Clone,
 
 impl<Req: PartialEq + Send + Clone,
      Res: PartialEq + Send + Clone> LocalClient<Req, Res> {
+    /// Creates a new Local Client with Given sender and receiver.
     pub const fn new(req_tx: Sender<Req>, res_rx: Receiver<Res>) -> Self {
         Self {req_tx, res_rx }
     }
@@ -36,13 +49,15 @@ impl<Req: PartialEq + Send + Clone,
 
 impl<Req: PartialEq + Send + Clone,
     Res: PartialEq + Send + Clone> LocalServerChannels<Req, Res> {
-    pub const fn new(req_rx: Receiver<Req>, res_tx: Sender<Res>) -> Self {
+    
+    const fn new(req_rx: Receiver<Req>, res_tx: Sender<Res>) -> Self {
         Self { req_rx, res_tx }
     }
 }
 
 impl<Req: PartialEq + Send + Clone,
      Res: PartialEq + Send + Clone> LocalServer<Req, Res> {
+    /// Creates a new Local Server
     pub fn new() -> Self {
         Self { client_mappings: HashMap::new() }
     }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,3 +1,11 @@
+//!
+//! Wrapper that manages the scheduling of Nodes.
+//! 
+//! An Executor should maintain references to a number of nodes and schedule their
+//! updates.  The idea here is that each executor can pretty much be its own thread
+//! that manages its own set of processes.
+//! 
+
 pub mod simple_executor;
 pub mod simple_multi_executor;
 pub mod node_wrapper;

--- a/src/executor/node_wrapper.rs
+++ b/src/executor/node_wrapper.rs
@@ -1,6 +1,11 @@
+//!
+//! The Node Wrapper wraps a mutable reference to a node with information regarding its next
+//! update timestamp.
+//! 
+
 use crate::node::Node;
 
-use std::{cmp::{Ord, Ordering}};
+use std::cmp::{Ord, Ordering};
 
 /// Wrapper for a node that gives it a priority based on its update rate
 /// 

--- a/src/executor/simple_executor.rs
+++ b/src/executor/simple_executor.rs
@@ -134,7 +134,7 @@ impl<'a> Executor<'a> for SimpleExecutor<'a> {
                 self.interrupted = interrupt;
             }
         }
-        return self.interrupted;
+        self.interrupted
     }
 
     fn log(&self, message: &str) {

--- a/src/executor/simple_executor.rs
+++ b/src/executor/simple_executor.rs
@@ -174,17 +174,17 @@ mod tests {
         // Check the first node is node 3
         let node_three = simple_executor.heap.pop().unwrap().node;
         assert_eq!(node_three.name(), String::from("test node 3"));
-        assert_eq!(node_three.get_update_rate(), 3);
+        assert_eq!(node_three.get_update_delay(), 3);
 
         // Check the second node is node 2
         let node_two = simple_executor.heap.pop().unwrap().node;
         assert_eq!(node_two.name(), String::from("test node 2"));
-        assert_eq!(node_two.get_update_rate(), 13);
+        assert_eq!(node_two.get_update_delay(), 13);
 
         // Check the third node is node 3
         let node_one = simple_executor.heap.pop().unwrap().node;
         assert_eq!(node_one.name(), String::from("test node 1"));
-        assert_eq!(node_one.get_update_rate(), 12);
+        assert_eq!(node_one.get_update_delay(), 12);
     }
 
     #[test]
@@ -231,27 +231,27 @@ mod tests {
             (Ok(mut executor_one), Ok(mut executor_two)) => {
                 let node_one = executor_one.heap.pop().unwrap().node;
                 assert_eq!(node_one.name(), String::from("test node 1"));
-                assert_eq!(node_one.get_update_rate(), 9);
+                assert_eq!(node_one.get_update_delay(), 9);
 
                 let node_three = executor_one.heap.pop().unwrap().node;
                 assert_eq!(node_three.name(), String::from("test node 3"));
-                assert_eq!(node_three.get_update_rate(), 12);
+                assert_eq!(node_three.get_update_delay(), 12);
 
                 let node_two = executor_one.heap.pop().unwrap().node;
                 assert_eq!(node_two.name(), String::from("test node 2"));
-                assert_eq!(node_two.get_update_rate(), 13);
+                assert_eq!(node_two.get_update_delay(), 13);
 
                 let node_five = executor_two.heap.pop().unwrap().node;
                 assert_eq!(node_five.name(), String::from("test node 5"));
-                assert_eq!(node_five.get_update_rate(), 5);
+                assert_eq!(node_five.get_update_delay(), 5);
 
                 let node_four = executor_two.heap.pop().unwrap().node;
                 assert_eq!(node_four.name(), String::from("test node 4"));
-                assert_eq!(node_four.get_update_rate(), 15);
+                assert_eq!(node_four.get_update_delay(), 15);
                 
                 let node_six = executor_two.heap.pop().unwrap().node;
                 assert_eq!(node_six.name(), String::from("test node 6"));
-                assert_eq!(node_six.get_update_rate(), 20);
+                assert_eq!(node_six.get_update_delay(), 20);
             },
             _ => assert_eq!(false, true),
         };
@@ -281,25 +281,25 @@ mod tests {
         let wrapper_two = simple_executor.heap.pop().unwrap();
         let node_two = wrapper_two.node;
         assert_eq!(node_two.name(), String::from("test node 2"));
-        assert_eq!(node_two.get_update_rate(), 4);
+        assert_eq!(node_two.get_update_delay(), 4);
         assert_eq!(wrapper_two.priority, 2000);
 
         let wrapper_four = simple_executor.heap.pop().unwrap();
         let node_four = wrapper_four.node;
         assert_eq!(node_four.name(), String::from("test node 4"));
-        assert_eq!(node_four.get_update_rate(), 2);
+        assert_eq!(node_four.get_update_delay(), 2);
         assert_eq!(wrapper_four.priority, 2000);
 
         let wrapper_three = simple_executor.heap.pop().unwrap();
         let node_three = wrapper_three.node;
         assert_eq!(node_three.name(), String::from("test node 3"));
-        assert_eq!(node_three.get_update_rate(), 5);
+        assert_eq!(node_three.get_update_delay(), 5);
         assert_eq!(wrapper_three.priority, 2005);
 
         let wrapper_one = simple_executor.heap.pop().unwrap();
         let node_one = wrapper_one.node;
         assert_eq!(node_one.name(), String::from("test node 1"));
-        assert_eq!(node_one.get_update_rate(), 15);
+        assert_eq!(node_one.get_update_delay(), 15);
         assert_eq!(wrapper_one.priority, 2010);
 
         assert!(2000 <= end_time - start_time && end_time - start_time <= 2002);

--- a/src/executor/simple_multi_executor.rs
+++ b/src/executor/simple_multi_executor.rs
@@ -17,7 +17,7 @@ use std::sync::{mpsc, mpsc::{Receiver, Sender}};
 
 /// Multi-Threaded Executor that maps a large number of single executors to
 /// strings (thread names) and manages the multi-threaded execution and interrupts for
-/// each of these executors
+/// each of these executors.
 pub struct SimpleMultiExecutor<'a> {
     threads: HashMap<String, SimpleExecutor<'a>>,
     interrupt_txs: Vec<Sender<bool>>,
@@ -81,6 +81,12 @@ impl<'a> SimpleMultiExecutor<'a> {
     }
 }
 
+impl<'a> Default for SimpleMultiExecutor<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> MultiThreadedExecutor<'a> for SimpleMultiExecutor<'a> {
     fn add_node_to(&mut self, new_node: &'a mut dyn Node, thread: &str) {
         let thread = String::from(thread);
@@ -118,7 +124,7 @@ impl<'a> Executor<'a> for SimpleMultiExecutor<'a> {
                 handles.push(scope.spawn(|| {
                     executor.start();
                     executor.update_loop();
-                    return executor;
+                    executor
                 }));
             }
 
@@ -138,7 +144,7 @@ impl<'a> Executor<'a> for SimpleMultiExecutor<'a> {
 
             self.log("Wind Down Complete");
 
-            return (thread_names, executors);
+            (thread_names, executors)
         });
 
         let mut map = HashMap::new();
@@ -168,7 +174,7 @@ impl<'a> Executor<'a> for SimpleMultiExecutor<'a> {
                 handles.push(scope.spawn(|| {
                     executor.start();
                     executor.update_loop();
-                    return executor;
+                    executor
                 }));
             }
 
@@ -190,7 +196,7 @@ impl<'a> Executor<'a> for SimpleMultiExecutor<'a> {
 
             self.log("Wind Down Complete");
 
-            return (thread_names, executors);
+            (thread_names, executors)
         });
 
         let mut map = HashMap::new();
@@ -208,7 +214,7 @@ impl<'a> Executor<'a> for SimpleMultiExecutor<'a> {
                 self.interrupted = interrupt;
             }
         }
-        return self.interrupted;
+        self.interrupted
     }
 
     fn log(&self, message: &str) {

--- a/src/executor/simple_multi_executor.rs
+++ b/src/executor/simple_multi_executor.rs
@@ -1,3 +1,12 @@
+//!
+//! Executor that manages multiple single-threaded executors (Preferred).
+//! 
+//! The Multi-Threaded Executor provides a simple-to-use api for users to add a large number
+//! of nodes to a large number of possible threads.  The basic premise of this executor
+//! is that there are a large number of single-threaded executors that are managed by a singular main
+//! thread that has the ability to monitor and interrupt the other executors.
+//! 
+
 use crate::executor::{Executor, SingleThreadedExecutor, MultiThreadedExecutor, simple_executor::SimpleExecutor};
 use crate::node::Node;
 
@@ -6,6 +15,9 @@ use std::time::Duration;
 use std::thread;
 use std::sync::{mpsc, mpsc::{Receiver, Sender}};
 
+/// Multi-Threaded Executor that maps a large number of single executors to
+/// strings (thread names) and manages the multi-threaded execution and interrupts for
+/// each of these executors
 pub struct SimpleMultiExecutor<'a> {
     threads: HashMap<String, SimpleExecutor<'a>>,
     interrupt_txs: Vec<Sender<bool>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,20 @@
+//!
+//! NComm is a rust-based replacement for Ros's communication system.
+//! 
+//! The main idea of NComm is that there should be many types of publishers, subscribers, clients, servers, update clients,
+//! and update servers.  Each of the types of communication should specialize on something.  For example, when publishing data
+//! between nodes in the same Rust program, there is no need to make this communication accessible via the internet as this will
+//! only slow down communication.  Instead, it makes more sense to use the local publisher (a channels based publisher) to send
+//! data efficiently.
+//! 
+//! Over time, I would like to expand the reaches of this library by adding various new communication types as I find them necessary.
+//! 
+//! I am also going to try my best to link projects that use this library so that new users can get a good idea of what NComm enables.
+//! 
+//! ## Projects
+//! * RoboJackets Robocup Base Station - <https://github.com/RoboJackets/robocup-base-station>
+//! 
+
 pub mod node;
 pub mod executor;
 pub mod publisher_subscriber;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,21 +1,23 @@
+//!
+//! A Singular Process.
+//! 
+//! In NComm (as with Ros) the main idea is to encapsulate singular processes into a singular Node.  
+//! The hope is that by encapsulating processes to specific structures it helps the readability and maintainability of robotics
+//! projects.
+//! 
+//! Take, for example, a system consisting of a few sensors and a web server.  To enhance the readability and maintainability
+//! of the project, it may be useful to separate each of the sensors into a specific Node that collects (and possibly processes)
+//! the various pieces of sensor data.  Then, it may be necessary to combine the data at another node that is running the web server.
+//! 
+//! Each of the Modules below contains various examples used internally to test executor functionalities.
+//! 
 pub mod basic_node;
 pub mod pubsub_node;
 pub mod client_server_node;
 pub mod update_client_server_node;
 pub mod udp_pubsub_node;
 
-/// struct Node {
-///     name/id: String/u64
-///     update_rate: u64
-///     list/vector<publishers> publishers
-///     list/vector<subscribers> subscribers
-///     list/vector<clients> clients
-///     list/vector<servers> servers
-///     list/vector<update_clients> update_clients
-///     list/vector<update_servers> update_servers
-/// }
-
-/// A Node should represent a comprehensive object/block of code that functions relatively independantly
+/// A Node should represent a comprehensive object/block of code that functions relatively independently
 /// from the other blocks of code.
 /// 
 /// All Nodes need to implement the following methods, which will be called by their executor.
@@ -26,11 +28,11 @@ pub trait Node: Send {
     /// Completes any important initialization methods for the node.
     fn start(&mut self);
 
-    /// Called every update_rate ms and is where the majority of user code will be located (should be overriden for any user defined nodes)
+    /// Called every update_rate ms and is where the majority of user code will be located (should be overridden for any user defined nodes)
     fn update(&mut self);
 
     /// Simply returns the node's update rate (in ms)
-    fn get_update_rate(&self) -> u128;
+    fn get_update_delay(&self) -> u128;
 
     /// When the program is stopped the node must contain logic to end any affairs it is currently entangled in.
     fn shutdown(&mut self);

--- a/src/node/basic_node.rs
+++ b/src/node/basic_node.rs
@@ -1,28 +1,23 @@
+//!
+//! Basic Node Example.
+//! 
+
 use crate::node::Node;
 
 /// Test Basic Node
 /// 
 /// This node was meant to test the most basic possible node that contains its own data and
 /// does its own processing.
-/// 
-/// Params:
-///     name: the name of the node
-///     update_rate: the rate the node should be updated at (in ms)
-///     test_number: the internal number that changes giving BasicNode state.
 pub struct BasicNode<'a> {
     name: &'a str,
-    update_rate: u128,
+    update_delay: u128,
     test_number: u128,
 }
 
 impl<'a> BasicNode<'a> {
-    /// Creates a new Basic Node with given name and update rate
-    /// 
-    /// Args:
-    ///     name: the name for the new Basic Node
-    ///     update_rate: the rate this node should be updated at (in ms)
-    pub const fn new(name: &'a str, update_rate: u128) -> Self {
-        Self{ name, update_rate, test_number: 0}
+    /// Creates a new Basic Node with given name and update delay
+    pub const fn new(name: &'a str, update_delay: u128) -> Self {
+        Self{ name, update_delay, test_number: 0}
     }
 }
 
@@ -39,8 +34,8 @@ impl<'a> Node for BasicNode<'a> {
         self.test_number += 1;
     }
 
-    fn get_update_rate(&self) -> u128 {
-        self.update_rate
+    fn get_update_delay(&self) -> u128 {
+        self.update_delay
     }
 
     fn shutdown(&mut self) {
@@ -51,7 +46,7 @@ impl<'a> Node for BasicNode<'a> {
         format!(
             "Basic Node:\n{}\n{}\n{}\n",
             self.name(),
-            self.update_rate,
+            self.update_delay,
             self.test_number,
         )
     }

--- a/src/node/basic_node.rs
+++ b/src/node/basic_node.rs
@@ -60,7 +60,7 @@ mod tests {
     fn test_create_basic_node() {
         let basic_node = BasicNode::new("test node", 12);
         assert_eq!(basic_node.name, String::from("test node"));
-        assert_eq!(basic_node.update_rate, 12);
+        assert_eq!(basic_node.update_delay, 12);
         assert_eq!(basic_node.test_number, 0);
     }
 
@@ -81,9 +81,9 @@ mod tests {
     }
 
     #[test]
-    fn test_get_update_rate() {
+    fn test_get_update_delay() {
         let basic_node = BasicNode::new("test node", 12);
-        assert_eq!(basic_node.get_update_rate(), 12);
+        assert_eq!(basic_node.get_update_delay(), 12);
     }
 
     #[test]

--- a/src/node/client_server_node.rs
+++ b/src/node/client_server_node.rs
@@ -166,14 +166,14 @@ mod tests {
         let client_node_two = ClientNode::new("test client node 2", 22, server_node.create_client(String::from("test client node 2")));
 
         assert_eq!(server_node.name(), String::from("test server node"));
-        assert_eq!(server_node.get_update_rate(), 10);
+        assert_eq!(server_node.get_update_delay(), 10);
 
         assert_eq!(client_node_one.name(), String::from("test client node 1"));
-        assert_eq!(client_node_one.get_update_rate(), 10);
+        assert_eq!(client_node_one.get_update_delay(), 10);
         assert_eq!(client_node_one.test_number, 0);
 
         assert_eq!(client_node_two.name(), String::from("test client node 2"));
-        assert_eq!(client_node_two.get_update_rate(), 22);
+        assert_eq!(client_node_two.get_update_delay(), 22);
         assert_eq!(client_node_two.test_number, 0);
     }
 

--- a/src/node/client_server_node.rs
+++ b/src/node/client_server_node.rs
@@ -1,3 +1,7 @@
+//!
+//! Basic Client + Server Node Example.
+//! 
+
 use std::num::Wrapping;
 
 use crate::node::Node;
@@ -5,56 +9,71 @@ use crate::node::Node;
 use crate::client_server::{Server, Client};
 use crate::client_server::local::{LocalClient, LocalServer};
 
+/// Request Sent from the Client to the Server.
 #[derive(PartialEq, Clone, Debug)]
 pub struct TestRequest {
     data: u128
 }
 impl TestRequest {
+    /// Creates a new Request with given data.
     pub const fn new(data: u128) -> Self {
         Self { data }
     }
 }
 
+/// Response Sent back from the Server to the Client
 #[derive(PartialEq, Clone, Debug)]
 pub struct TestResponse {
     data: u128
 }
 impl TestResponse {
+    /// Creates a new Response with given data.
     pub const fn new(data: u128) -> Self {
         Self { data }
     }
 }
 
+/// Test Server Node
+/// 
+/// This node is used to test the most basic possible node that contains a
+/// local server.
 pub struct ServerNode<'a> {
     name: &'a str,
-    update_rate: u128,
+    update_delay: u128,
     test_server: LocalServer<TestRequest, TestResponse>,
 }
 
+/// Test Client Node
+/// 
+/// This node is used to test the most basic possible node that contains a
+/// local client.
 pub struct ClientNode<'a> {
     name: &'a str,
-    update_rate: u128,
+    update_delay: u128,
     test_number: u128,
     test_client: LocalClient<TestRequest, TestResponse>,
 }
 
 impl<'a> ServerNode<'a> {
-    pub fn new(name: &'a str, update_rate: u128) -> Self {
+    /// Creates a new Server node with given name and update delay
+    pub fn new(name: &'a str, update_delay: u128) -> Self {
         Self{
             name,
-            update_rate,
+            update_delay,
             test_server: LocalServer::new()
         }
     }
 
+    /// Create a new client for this node's server
     pub fn create_client(&mut self, client_name: String) -> LocalClient<TestRequest, TestResponse> {
         self.test_server.create_client(client_name)
     }
 }
 
 impl<'a> ClientNode<'a> {
-    pub const fn new(name: &'a str, update_rate: u128, client: LocalClient<TestRequest, TestResponse>) -> Self {
-        Self { name, update_rate, test_number: 0, test_client: client }
+    /// Create a new Client Node with given name, update delay and client.
+    pub const fn new(name: &'a str, update_delay: u128, client: LocalClient<TestRequest, TestResponse>) -> Self {
+        Self { name, update_delay, test_number: 0, test_client: client }
     }
 }
 
@@ -74,8 +93,8 @@ impl<'a> Node for ServerNode<'a> {
         self.test_server.send_responses(responses);
     }
 
-    fn get_update_rate(&self) -> u128 {
-        self.update_rate
+    fn get_update_delay(&self) -> u128 {
+        self.update_delay
     }
 
     fn shutdown(&mut self) {
@@ -91,7 +110,7 @@ impl<'a> Node for ServerNode<'a> {
         format!(
             "Server Node:\n{}\n{}",
             self.name(),
-            self.update_rate,
+            self.update_delay,
         )
     }
 }
@@ -116,8 +135,8 @@ impl<'a> Node for ClientNode<'a> {
         let _err = self.test_client.send_request(TestRequest{ data: self.test_number });
     }
 
-    fn get_update_rate(&self) -> u128 {
-        self.update_rate
+    fn get_update_delay(&self) -> u128 {
+        self.update_delay
     }
 
     fn shutdown(&mut self) {
@@ -130,7 +149,7 @@ impl<'a> Node for ClientNode<'a> {
         format!(
         "Client Node:\n{}\n{}\n{}",
         self.name(),
-        self.update_rate,
+        self.update_delay,
         self.test_number
         )
     }

--- a/src/node/pubsub_node.rs
+++ b/src/node/pubsub_node.rs
@@ -1,3 +1,7 @@
+//!
+//! Basic Publisher + Server Node Example.
+//! 
+
 use crate::node::Node;
 
 use crate::publisher_subscriber::{Publish, Subscribe, Receive, local::{LocalPublisher, LocalSubscriber}};
@@ -6,15 +10,9 @@ use crate::publisher_subscriber::{Publish, Subscribe, Receive, local::{LocalPubl
 /// 
 /// This node was created to both demo the usage of the LocalPublisher and to debug
 /// the LocalPublisher to ensure it works correctly.
-/// 
-/// Params:
-///     name: the name of this node
-///     update_rate: the rate at which this node should be updated (ms)
-///     test_number: the current test number this node contains
-///     num_publisher: the LocalPublisher that will publish u128s.
 pub struct PublisherNode<'a> {
     name: &'a str,
-    update_rate: u128,
+    update_delay: u128,
     test_number: u128,
     num_publisher: LocalPublisher<u128>,
 }
@@ -23,28 +21,18 @@ pub struct PublisherNode<'a> {
 /// 
 /// This node was created to both demo the usage of the LocalSubscriber and to
 /// debug the LocalSubscriber to ensure it works correctly
-/// 
-/// Params:
-///     name: the name of this node
-///     update_rate: the rate at which this node should be updated (ms)
-///     num_subscriber: the LocalSubscriber that will subscribe to updates from the
-///         LocalPublisherNode
 pub struct SubscriberNode<'a> {
     name: &'a str,
-    update_rate: u128,
+    update_delay: u128,
     num_subscriber: Option<LocalSubscriber<u128>>,
 }
 
 impl<'a> PublisherNode<'a> {
     /// Creates a new PublisherNode
-    /// 
-    /// Args:
-    ///     name: the name for this publisher node
-    ///     update_rate: the update rate (in ms) of this publisher node
-    pub const fn new(name: &'a str, update_rate: u128) -> Self {
+    pub const fn new(name: &'a str, update_delay: u128) -> Self {
         Self{
             name,
-            update_rate,
+            update_delay,
             test_number: 0,
             num_publisher: LocalPublisher::new(),
         }
@@ -58,18 +46,15 @@ impl<'a> PublisherNode<'a> {
 
 impl<'a> SubscriberNode<'a> {
     /// Creates a new subscriber node
-    /// 
-    /// Args:
-    ///     name: the name of this subscriber node
-    ///     update_rate: the update rate (in ms) of this subscriber node
-    pub const fn new(name: &'a str, update_rate: u128) -> Self {
+    pub const fn new(name: &'a str, update_delay: u128) -> Self {
         Self{
             name,
-            update_rate,
+            update_delay,
             num_subscriber: None,
         }
     }
 
+    /// Adds a subscriber endpoint to this Node's num_subscriber endpoint.
     pub fn add_num_subscriber_subscriber(&mut self, subscriber: LocalSubscriber<u128>) {
         self.num_subscriber = Some(subscriber);
     }
@@ -90,8 +75,8 @@ impl<'a> Node for PublisherNode<'a> {
         self.num_publisher.send(self.test_number);
     }
 
-    fn get_update_rate(&self) -> u128 {
-        self.update_rate
+    fn get_update_delay(&self) -> u128 {
+        self.update_delay
     }
 
     fn shutdown(&mut self) {
@@ -102,7 +87,7 @@ impl<'a> Node for PublisherNode<'a> {
         format!(
             "Publisher Node:\n{}\n{}\n{}",
             self.name(),
-            self.update_rate,
+            self.update_delay,
             self.test_number,
         )
     }
@@ -121,8 +106,8 @@ impl<'a> Node for SubscriberNode<'a> {
         self.num_subscriber.as_mut().unwrap().update_data();
     }
 
-    fn get_update_rate(&self) -> u128 {
-        self.update_rate
+    fn get_update_delay(&self) -> u128 {
+        self.update_delay
     }
 
     fn shutdown(&mut self) {}
@@ -131,7 +116,7 @@ impl<'a> Node for SubscriberNode<'a> {
         format!(
             "Subscriber Node:\n{}\n{}\n{}",
             self.name(),
-            self.update_rate,
+            self.update_delay,
             self.num_subscriber.as_ref().unwrap().data.unwrap(),
         )
     }

--- a/src/node/pubsub_node.rs
+++ b/src/node/pubsub_node.rs
@@ -132,11 +132,11 @@ mod tests {
         let subscriber_node = SubscriberNode::new("test subscriber", 10);
 
         assert_eq!(publisher_node.name(), String::from("test publisher"));
-        assert_eq!(publisher_node.update_rate, 12);
+        assert_eq!(publisher_node.update_delay, 12);
         assert_eq!(publisher_node.test_number, 0);
         
         assert_eq!(subscriber_node.name(), String::from("test subscriber"));
-        assert_eq!(subscriber_node.update_rate, 10);
+        assert_eq!(subscriber_node.update_delay, 10);
         assert!(subscriber_node.num_subscriber.is_none());
     }
 
@@ -151,11 +151,11 @@ mod tests {
         subscriber_node.start();
 
         assert_eq!(publisher_node.name(), String::from("test publisher"));
-        assert_eq!(publisher_node.get_update_rate(), 13);
+        assert_eq!(publisher_node.get_update_delay(), 13);
         assert_eq!(publisher_node.test_number, 1);
 
         assert_eq!(subscriber_node.name(), String::from("test subscriber"));
-        assert_eq!(subscriber_node.get_update_rate(), 10);
+        assert_eq!(subscriber_node.get_update_delay(), 10);
         assert_eq!(subscriber_node.num_subscriber.unwrap().data.unwrap(), 1);
     }
 
@@ -173,11 +173,11 @@ mod tests {
         subscriber_node.update();
 
         assert_eq!(publisher_node.name(), String::from("test publisher"));
-        assert_eq!(publisher_node.get_update_rate(), 12);
+        assert_eq!(publisher_node.get_update_delay(), 12);
         assert_eq!(publisher_node.test_number, 2);
 
         assert_eq!(subscriber_node.name(), String::from("test subscriber"));
-        assert_eq!(subscriber_node.get_update_rate(), 10);
+        assert_eq!(subscriber_node.get_update_delay(), 10);
         assert_eq!(subscriber_node.num_subscriber.unwrap().data.unwrap(), 2);
     }
 }

--- a/src/node/udp_pubsub_node.rs
+++ b/src/node/udp_pubsub_node.rs
@@ -45,7 +45,7 @@ impl<'a> UdpSubscriberNode<'a> {
         Self {
             name,
             update_delay,
-            num_subscriber: UdpSubscriber::new(bind_address, from_address),
+            num_subscriber: UdpSubscriber::new(bind_address, Some(from_address)),
         }
     }
 }

--- a/src/node/udp_pubsub_node.rs
+++ b/src/node/udp_pubsub_node.rs
@@ -125,11 +125,11 @@ mod tests {
         );
 
         assert_eq!(publisher_node.name(), String::from("publisher node"));
-        assert_eq!(publisher_node.get_update_rate(), 20);
+        assert_eq!(publisher_node.get_update_delay(), 20);
         assert_eq!(publisher_node.test_number, 0);
 
         assert_eq!(subscriber_node.name(), String::from("subscriber node"));
-        assert_eq!(subscriber_node.get_update_rate(), 20);
+        assert_eq!(subscriber_node.get_update_delay(), 20);
         assert!(subscriber_node.num_subscriber.data.is_none());
     }
 

--- a/src/node/udp_pubsub_node.rs
+++ b/src/node/udp_pubsub_node.rs
@@ -1,3 +1,7 @@
+//!
+//! Basic UDP Publisher + Client Example.
+//! 
+
 use crate::node::Node;
 
 use crate::publisher_subscriber::{Publish, Receive, udp::{UdpPublisher, UdpSubscriber}};
@@ -6,15 +10,9 @@ use crate::publisher_subscriber::{Publish, Receive, udp::{UdpPublisher, UdpSubsc
 /// 
 /// This node was created to both demo the usage of the UdpPublisher and to debug
 /// the UdpPublisher to ensure it works correctly
-/// 
-/// Params:
-///     name: the name of this node
-///     update_rate: the rate at which this node should be updated (ms)
-///     test_number: the current test number this node contains
-///     num_publisher: the UdpPublisher that will publish a singular u8
 pub struct UdpPublisherNode<'a> {
     name: &'a str,
-    update_rate: u128,
+    update_delay: u128,
     test_number: u8,
     num_publisher: UdpPublisher<'a, u8, 1>,
 }
@@ -23,30 +21,18 @@ pub struct UdpPublisherNode<'a> {
 /// 
 /// This node was created to both demo the usage of the UdpSubsciber and to debug
 /// the UdpSubscriber to ensure it works correctly
-/// 
-/// Params:
-///     name: the name of this node
-///     update_rate: the rate at which this node should be updated (ms)
-///     num_subscriber: the UdpSubscriber that will subscribe to the updates of the above
-///         UdpPublisherNode.
 pub struct UdpSubscriberNode<'a> {
     name: &'a str,
-    update_rate: u128,
+    update_delay: u128,
     num_subscriber: UdpSubscriber<u8, 1>,
 }
 
 impl<'a> UdpPublisherNode<'a> {
     /// Creates a new UdpPublisherNode
-    /// 
-    /// Args:
-    ///     name: the name for this publisher node
-    ///     update_rate: the update rate (in ms) of this udp publisher node
-    ///     bind_address: the address this publisher should bind to
-    ///     addresses: the addresses this udp publisher node should send to
-    pub fn new(name: &'a str, update_rate: u128, bind_address: &'a str, addresses: Vec<&'a str>) -> Self {
+    pub fn new(name: &'a str, update_delay: u128, bind_address: &'a str, addresses: Vec<&'a str>) -> Self {
         Self {
             name,
-            update_rate,
+            update_delay,
             test_number: 0,
             num_publisher: UdpPublisher::new(bind_address, addresses),
         }
@@ -55,16 +41,10 @@ impl<'a> UdpPublisherNode<'a> {
 
 impl<'a> UdpSubscriberNode<'a> {
     /// Creates a new UdpSubscriberNode
-    /// 
-    /// Args:
-    ///     name: the name for this subscriber ndoe
-    ///     update_rate: the update rate (in ms) of this udp subscriber node
-    ///     bind_address: the address this subscriber should bind to
-    ///     from_address: the address this subscriber should look at data from
-    pub fn new(name: &'a str, update_rate: u128, bind_address: &'a str, from_address: &'a str) -> Self {
+    pub fn new(name: &'a str, update_delay: u128, bind_address: &'a str, from_address: &'a str) -> Self {
         Self {
             name,
-            update_rate,
+            update_delay,
             num_subscriber: UdpSubscriber::new(bind_address, from_address),
         }
     }
@@ -73,7 +53,7 @@ impl<'a> UdpSubscriberNode<'a> {
 impl<'a> Node for UdpPublisherNode<'a> {
     fn name(&self) -> String { String::from(self.name) }
 
-    fn get_update_rate(&self) -> u128 { self.update_rate }
+    fn get_update_delay(&self) -> u128 { self.update_delay }
 
     fn start(&mut self) {
         self.test_number = 1;
@@ -93,7 +73,7 @@ impl<'a> Node for UdpPublisherNode<'a> {
         format!(
             "UDP Publisher Node:\n{}\n{}\n{}",
             self.name(),
-            self.update_rate,
+            self.update_delay,
             self.test_number,
         )
     }
@@ -102,7 +82,7 @@ impl<'a> Node for UdpPublisherNode<'a> {
 impl<'a> Node for UdpSubscriberNode<'a> {
     fn name(&self) -> String { String::from(self.name) }
 
-    fn get_update_rate(&self) -> u128 { self.update_rate }
+    fn get_update_delay(&self) -> u128 { self.update_delay }
 
     fn start(&mut self) {}
 
@@ -118,7 +98,7 @@ impl<'a> Node for UdpSubscriberNode<'a> {
         format!(
             "UDP Subscriber Node:\n{}\n{}\n{:?}",
             self.name(),
-            self.update_rate,
+            self.update_delay,
             if let Some(data) = self.num_subscriber.data { data } else { 0 },
         )
     }

--- a/src/node/update_client_server_node.rs
+++ b/src/node/update_client_server_node.rs
@@ -1,8 +1,13 @@
+//!
+//! Basic Update Client + Server Node Example.
+//! 
+
 use crate::node::Node;
 
 use crate::update_client_server::{UpdateServer, UpdateClient};
 use crate::update_client_server::local::{LocalUpdateClient, LocalUpdateServer};
 
+/// Request Sent from the Update Client to the Update Server
 #[derive(PartialEq, Clone, Debug)]
 pub struct TestRequest {
     data: u128
@@ -13,6 +18,7 @@ impl TestRequest {
     }
 }
 
+/// Update Sent from the Update Server back to the Update Client
 #[derive(PartialEq, Clone, Debug)]
 pub struct TestUpdate {
     data: u128
@@ -23,6 +29,7 @@ impl TestUpdate {
     }
 }
 
+/// Final Response Sent from the Update Server back to the Update Client
 #[derive(PartialEq, Clone, Debug)]
 pub struct TestResponse {
     data: u128
@@ -33,28 +40,37 @@ impl TestResponse {
     }
 }
 
+/// Test Update Server Node
+/// 
+/// This node is used to test the most basic functionality of the local update
+/// server.
 pub struct UpdateServerNode<'a> {
     name: &'a str,
-    update_rate: u128,
+    update_delay: u128,
     test_number: u128,
     received_requests: u128,
     num_sent_updates: u8,
     test_server: LocalUpdateServer<TestRequest, TestUpdate, TestResponse>,
 }
 
+/// Test Update Client Node
+/// 
+/// This node is used to test the most basic functionality of the local update
+/// client.
 pub struct UpdateClientNode<'a> {
     name: &'a str,
-    update_rate: u128,
+    update_delay: u128,
     test_number: u128,
     test_client: LocalUpdateClient<TestRequest, TestUpdate, TestResponse>,
     sent_first_request: bool,
 }
 
 impl<'a> UpdateServerNode<'a> {
-    pub fn new(name: &'a str, update_rate: u128) -> Self {
+    /// Create a new Update Server Node
+    pub fn new(name: &'a str, update_delay: u128) -> Self {
         Self {
             name,
-            update_rate,
+            update_delay,
             test_number: 0,
             received_requests: 0,
             num_sent_updates: 0,
@@ -62,16 +78,18 @@ impl<'a> UpdateServerNode<'a> {
         }
     }
 
+    /// Create an Update Client Endpoint
     pub fn create_update_client(&mut self, client: String) -> LocalUpdateClient<TestRequest, TestUpdate, TestResponse> {
         self.test_server.create_update_client(client)
     }
 }
 
 impl<'a> UpdateClientNode<'a> {
-    pub const fn new(name: &'a str, update_rate: u128, client: LocalUpdateClient<TestRequest, TestUpdate, TestResponse>) -> Self {
+    /// Create a new Update Client Node.
+    pub const fn new(name: &'a str, update_delay: u128, client: LocalUpdateClient<TestRequest, TestUpdate, TestResponse>) -> Self {
         Self {
             name,
-            update_rate,
+            update_delay,
             test_number: 0,
             test_client: client,
             sent_first_request: false,
@@ -86,6 +104,10 @@ impl<'a> Node for UpdateServerNode<'a> {
 
     fn start(&mut self) {
         self.test_number = 1;
+    }
+
+    fn get_update_delay(&self) -> u128 {
+        self.update_delay
     }
 
     fn update(&mut self) {
@@ -117,10 +139,6 @@ impl<'a> Node for UpdateServerNode<'a> {
         }
     }
 
-    fn get_update_rate(&self) -> u128 {
-        self.update_rate
-    }
-
     fn shutdown(&mut self) {
         let clients = self.test_server.get_clients();
         let mut responses = Vec::with_capacity(clients.len());
@@ -135,7 +153,7 @@ impl<'a> Node for UpdateServerNode<'a> {
         format!(
             "Update Server Node:\n{}\n{}\n{}",
             self.name(),
-            self.update_rate,
+            self.update_delay,
             self.test_number
         )
     }
@@ -148,6 +166,10 @@ impl<'a> Node for UpdateClientNode<'a> {
 
     fn start(&mut self) {
         self.test_number = 1;
+    }
+
+    fn get_update_delay(&self) -> u128 {
+        self.update_delay
     }
 
     fn update(&mut self) {
@@ -170,10 +192,6 @@ impl<'a> Node for UpdateClientNode<'a> {
         }
     }
 
-    fn get_update_rate(&self) -> u128 {
-        self.update_rate
-    }
-
     fn shutdown(&mut self) {
         if let Some(response) = self.test_client.receive_response() {
             self.test_number = response.data;
@@ -184,7 +202,7 @@ impl<'a> Node for UpdateClientNode<'a> {
         format!(
             "Update Client Node:\n{}\n{}\n{}",
             self.name(),
-            self.update_rate,
+            self.update_delay,
             self.test_number
         )
     }

--- a/src/node/update_client_server_node.rs
+++ b/src/node/update_client_server_node.rs
@@ -114,7 +114,7 @@ impl<'a> Node for UpdateServerNode<'a> {
         if (self.received_requests as usize) < self.test_server.get_clients().len() {
             let requests = self.test_server.receive_requests();
 
-            if requests.is_empty() {
+            if !requests.is_empty() {
                 self.test_number = requests[0].1.data;
                 self.received_requests += requests.len() as u128;
             }
@@ -219,7 +219,7 @@ mod tests {
         let client_node_two = UpdateClientNode::new("test update client node two", 20, server_node.create_update_client(String::from("test update client node two")));
 
         assert_eq!(server_node.name(), String::from("test update server node"));
-        assert_eq!(server_node.get_update_rate(), 20);
+        assert_eq!(server_node.get_update_delay(), 20);
         assert_eq!(server_node.test_number, 0);
         assert_eq!(server_node.test_server.get_clients().len(), 2);
         assert!(server_node.test_server.get_clients()[0] == String::from("test update client node one") || server_node.test_server.get_clients()[0] == String::from("test update client node two"));
@@ -228,12 +228,12 @@ mod tests {
         assert_eq!(server_node.num_sent_updates, 0);
 
         assert_eq!(client_node_one.name(), String::from("test update client node one"));
-        assert_eq!(client_node_one.get_update_rate(), 20);
+        assert_eq!(client_node_one.get_update_delay(), 20);
         assert_eq!(client_node_one.test_number, 0);
         assert_eq!(client_node_one.sent_first_request, false);
 
         assert_eq!(client_node_two.name(), String::from("test update client node two"));
-        assert_eq!(client_node_two.get_update_rate(), 20);
+        assert_eq!(client_node_two.get_update_delay(), 20);
         assert_eq!(client_node_two.test_number, 0);
         assert_eq!(client_node_two.sent_first_request, false);
     }
@@ -249,7 +249,7 @@ mod tests {
         client_node_two.start();
 
         assert_eq!(server_node.name(), String::from("test update server node"));
-        assert_eq!(server_node.get_update_rate(), 20);
+        assert_eq!(server_node.get_update_delay(), 20);
         assert_eq!(server_node.test_number, 1);
         assert_eq!(server_node.test_server.get_clients().len(), 2);
         assert!(server_node.test_server.get_clients()[0] == String::from("test update client node one") || server_node.test_server.get_clients()[0] == String::from("test update client node two"));
@@ -258,12 +258,12 @@ mod tests {
         assert_eq!(server_node.num_sent_updates, 0);
 
         assert_eq!(client_node_one.name(), String::from("test update client node one"));
-        assert_eq!(client_node_one.get_update_rate(), 20);
+        assert_eq!(client_node_one.get_update_delay(), 20);
         assert_eq!(client_node_one.test_number, 1);
         assert_eq!(client_node_one.sent_first_request, false);
 
         assert_eq!(client_node_two.name(), String::from("test update client node two"));
-        assert_eq!(client_node_two.get_update_rate(), 20);
+        assert_eq!(client_node_two.get_update_delay(), 20);
         assert_eq!(client_node_two.test_number, 1);
         assert_eq!(client_node_two.sent_first_request, false);
     }

--- a/src/node/update_client_server_node.rs
+++ b/src/node/update_client_server_node.rs
@@ -114,7 +114,7 @@ impl<'a> Node for UpdateServerNode<'a> {
         if (self.received_requests as usize) < self.test_server.get_clients().len() {
             let requests = self.test_server.receive_requests();
 
-            if requests.len() > 0 {
+            if requests.is_empty() {
                 self.test_number = requests[0].1.data;
                 self.received_requests += requests.len() as u128;
             }

--- a/src/publisher_subscriber.rs
+++ b/src/publisher_subscriber.rs
@@ -1,3 +1,10 @@
+//!
+//! Publisher - Subscriber Communication
+//! 
+//! The Publish, Subscribe, and Receive Traits should be implemented for any and all
+//! future publishers and subscribers that are usable with NComm
+//! 
+
 pub mod local;
 pub mod udp;
 

--- a/src/publisher_subscriber/local.rs
+++ b/src/publisher_subscriber/local.rs
@@ -49,7 +49,7 @@ impl<Data: Send + Clone> Subscribe<Data> for LocalPublisher<Data> {
     fn create_subscriber(&mut self) -> LocalSubscriber<Data> {
         let (tx, rx): (Sender<Data>, Receiver<Data>) = mpsc::channel();
         self.txs.push(tx);
-        return LocalSubscriber::new_empty(rx);
+        LocalSubscriber::new_empty(rx)
     }
 }
 
@@ -66,10 +66,10 @@ impl <Data: Send + Clone> LocalSubscriber<Data> {
 impl<Data: Send + Clone> Receive for LocalSubscriber<Data> {
     fn update_data(&mut self) {
         let iter = self.rx.try_iter();
-        match iter.last() {
-            Some(data) => self.data = Some(data),
-            _ => return,
-        };
+
+        if let Some(data) = iter.last() {
+            self.data = Some(data);
+        }
     }
 }
 

--- a/src/publisher_subscriber/local.rs
+++ b/src/publisher_subscriber/local.rs
@@ -1,3 +1,10 @@
+//!
+//! A local mpsc channel-based Publisher + Subscriber
+//! 
+//! The Local Publisher sends data along a mpsc channel (cloned which may change)
+//! to a set of subscribers.
+//! 
+
 use std::sync::{mpsc, mpsc::{Sender, Receiver}};
 
 use crate::publisher_subscriber::{Publish, Subscribe, Receive};
@@ -6,9 +13,6 @@ use crate::publisher_subscriber::{Publish, Subscribe, Receive};
 /// 
 /// Publishers can create subscriptions and will send the same data
 /// (cloned) to each of its subscriptions
-/// 
-/// Params:
-///     txs: a list of the Sender<T> ends for the publisher subscriber channel
 pub struct LocalPublisher<Data: Send + Clone> {
     txs: Vec<Sender<Data>>,
 }
@@ -18,10 +22,6 @@ pub struct LocalPublisher<Data: Send + Clone> {
 /// Subscribers will receive data from a subscriber and store only the most recent
 /// data internally allowing for Nodes that contain subscribers to be able to access
 /// the most recent data.
-/// 
-/// Params:
-///     rx: the Receiver<T> end for the publisher's channel
-///     data: the most recent data from the publisher (None on init)
 pub struct LocalSubscriber<Data: Send + Clone> {
     rx: Receiver<Data>,
     pub data: Option<Data>,
@@ -29,9 +29,6 @@ pub struct LocalSubscriber<Data: Send + Clone> {
 
 impl<Data: Send + Clone> LocalPublisher<Data> {
     /// Creates a new Publisher with empty vector of Sender<T> ends
-    /// 
-    /// Returns:
-    ///     Publisher<T>: new Publisher
     pub const fn new() -> Self {
         Self{ txs: Vec::new() }
     }

--- a/src/publisher_subscriber/udp.rs
+++ b/src/publisher_subscriber/udp.rs
@@ -1,3 +1,9 @@
+//!
+//! A Network Udp-Based Publisher + Subscriber
+//! 
+//! The UDP Publisher sends data as a UDP Datagram to some other Subscriber.
+//! 
+
 use std::net::UdpSocket;
 use std::marker::PhantomData;
 
@@ -8,11 +14,6 @@ use crate::publisher_subscriber::{Publish, SubscribeRemote, Receive};
 /// Publishers can create subscriptions (in this case add addresses) and will send
 /// the same data to each of its subscriptions.  This Publisher will use a UDP socket
 /// to send data to the subscribers.
-/// 
-/// Params:
-///     tx: the UDP socket to send the data through
-///     addresses: a list of &str to send the data to
-///     phantom: the data type being sent
 pub struct UdpPublisher<'a, Data: Send + Clone, const DATA_SIZE: usize> {
     tx: UdpSocket,
     addresses: Vec<&'a str>,
@@ -24,10 +25,6 @@ pub struct UdpPublisher<'a, Data: Send + Clone, const DATA_SIZE: usize> {
 /// Subscribers will receive data from the subscriber and store only the most recent data.
 /// In this case, the UDP Subscriber will listen on a UDP socket connection for incoming traffic.
 /// It will then store the most recent datagram (decoded) internally
-/// 
-/// Params:
-///     rx: the receiving end of a UdpSocket
-///     data: the most recent data from the publisher (None on init)
 pub struct  UdpSubscriber<Data: Send + Clone, const DATA_SIZE: usize> {
     rx: UdpSocket,
     pub data: Option<Data>,
@@ -36,13 +33,6 @@ pub struct  UdpSubscriber<Data: Send + Clone, const DATA_SIZE: usize> {
 impl<'a, Data: Send + Clone, const DATA_SIZE: usize> UdpPublisher<'a, Data, DATA_SIZE> {
     /// Creates a new UdpPublisher with a UdpSocket bound to the bind address and a stored
     /// vector of references to the addresses of the subscribers.
-    /// 
-    /// Args:
-    ///     bind_address: the address this publisher should bind to
-    ///     addresses: a vector of the external UDP IP addresses this publisher should send to
-    /// 
-    /// Returns:
-    ///     UdpPublisher: A udp publisher bound to the bind address that can send to the address list
     pub fn new(bind_address: &'a str, addresses: Vec<&'a str>) -> Self {
         let socket = UdpSocket::bind(bind_address).expect("couldn't bind to the given address");
         socket.set_nonblocking(true).unwrap();
@@ -55,16 +45,12 @@ impl<'a, Data: Send + Clone, const DATA_SIZE: usize>  UdpSubscriber<Data, DATA_S
     /// Creates a new UdpSubscriber with a UdpSocket bound to the bind address listening to the from
     /// address.
     /// 
-    /// 
-    /// Args:
-    ///     bind_address: the address to bind to
-    ///     from_address: the address to listen to
-    /// 
-    /// Returns:
-    ///     UdpSubscriber: a udp subscriber bound to the bind address receiving communication from the from address.
-    pub fn new(bind_address: &'a str, from_address: &'a str) -> Self {
+    /// To only listen to communication to this bound address with a specific address, set from_address to Some value.
+    pub fn new(bind_address: &'a str, from_address: Option<&'a str>) -> Self {
         let socket = UdpSocket::bind(bind_address).expect("couldn't bind to the given address");
-        socket.connect(from_address).expect("couldn't connect to the given address");
+        if let Some(from_address) = from_address {
+            socket.connect(from_address).expect("couldn't connect to the given address");
+        }
         socket.set_nonblocking(true).unwrap();
 
         Self { rx: socket, data: None }
@@ -113,7 +99,7 @@ mod tests {
     #[test]
     // Test that a udp publisher and subscriber can be created.
     fn test_create_udp_publisher_and_subscriber() {
-        let subscriber:  UdpSubscriber<u8, 1> =  UdpSubscriber::new("127.0.0.1:8001", "127.0.0.1:8000");
+        let subscriber:  UdpSubscriber<u8, 1> =  UdpSubscriber::new("127.0.0.1:8001", Some("127.0.0.1:8000"));
         let publisher: UdpPublisher<u8, 1> = UdpPublisher::new("127.0.0.1:8000", vec!["127.0.0.1:8001"]);
 
         assert_eq!(subscriber.rx.local_addr().unwrap(), SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8001)));
@@ -126,7 +112,7 @@ mod tests {
     #[test]
     // Test that a udp publisher and subscriber can send data between each other.
     fn test_send_data_udp_publisher_and_subscriber() {
-        let mut subscriber:  UdpSubscriber<u8, 1> =  UdpSubscriber::new("127.0.0.1:8001", "127.0.0.1:8000");
+        let mut subscriber:  UdpSubscriber<u8, 1> =  UdpSubscriber::new("127.0.0.1:8001", Some("127.0.0.1:8000"));
         let publisher: UdpPublisher<u8, 1> = UdpPublisher::new("127.0.0.1:8000", vec!["127.0.0.1:8001"]);
 
         publisher.send(5u8);
@@ -142,7 +128,7 @@ mod tests {
     #[test]
     // Test that a udp publisher and subscriber can send multiple datas between each other.
     fn test_send_many_data_udp_publisher_and_subscriber() {
-        let mut subscriber:  UdpSubscriber<u8, 1> =  UdpSubscriber::new("127.0.0.1:7001", "127.0.0.1:7000");
+        let mut subscriber:  UdpSubscriber<u8, 1> =  UdpSubscriber::new("127.0.0.1:7001", Some("127.0.0.1:7000"));
         let publisher: UdpPublisher<u8, 1> = UdpPublisher::new("127.0.0.1:7000", vec!["127.0.0.1:7001"]);
 
         for i in 0..=8u8 {

--- a/src/publisher_subscriber/udp.rs
+++ b/src/publisher_subscriber/udp.rs
@@ -37,7 +37,7 @@ impl<'a, Data: Send + Clone, const DATA_SIZE: usize> UdpPublisher<'a, Data, DATA
         let socket = UdpSocket::bind(bind_address).expect("couldn't bind to the given address");
         socket.set_nonblocking(true).unwrap();
         
-        Self { tx: socket, addresses: addresses, phantom: PhantomData }
+        Self { tx: socket, addresses, phantom: PhantomData }
     }
 }
 

--- a/src/update_client_server.rs
+++ b/src/update_client_server.rs
@@ -1,3 +1,13 @@
+//!
+//! Update Client - Update Server Communication
+//! 
+//! An Update Client + Server is a normal client that expects updates from the update server regarding
+//! the status of the request that was sent.
+//! 
+//! Over time, a large number of update clients and servers will be developed using various methods
+//! of data transfer and each should implement the UpdateClient and UpdateServer traits.
+//! 
+
 pub mod local;
 
 use std::error::Error;

--- a/src/update_client_server/local.rs
+++ b/src/update_client_server/local.rs
@@ -1,4 +1,11 @@
-use std::{sync::{mpsc, mpsc::{Sender, Receiver}}};
+//!
+//! A local mpsc channel-based Update Client + Update Server
+//! 
+//! The Local Update Client + Server sends data along a mpsc channel from the client to
+//! the server and then updates and responses from the server back to the client.
+//! 
+
+use std::sync::{mpsc, mpsc::{Sender, Receiver}};
 use std::collections::HashMap;
 
 use crate::client_server::local::SendError;
@@ -6,11 +13,6 @@ use crate::client_server::local::SendError;
 use crate::update_client_server::{UpdateClient, UpdateServer};
 
 /// Local Implementation of an Update Client
-/// 
-/// Params:
-///     req_tx: the sender from this client to the server
-///     updt_rx: the receiver from the server to this client for updates
-///     res_rx: the receiver from the server to this client for responses
 pub struct LocalUpdateClient<Req: PartialEq + Send + Clone,
                              Updt: PartialEq + Send + Clone,
                              Res: PartialEq + Send + Clone> {
@@ -20,11 +22,6 @@ pub struct LocalUpdateClient<Req: PartialEq + Send + Clone,
 }
 
 /// Local Implementation of an group of server to client channels
-/// 
-/// Params:
-///     req_rx: the receiver from the client to this server for requests
-///     updt_tx: the sender from this server to the client (for updates)
-///     res_tx: the sender from this server to the client (for responses)
 struct LocalUpdateServerChannels<Req: PartialEq + Send + Clone,
                                  Updt: PartialEq + Send + Clone,
                                  Res: PartialEq + Send + Clone> {
@@ -34,10 +31,6 @@ struct LocalUpdateServerChannels<Req: PartialEq + Send + Clone,
 }
 
 /// Local Implementation of an Update Server
-/// 
-/// Params:
-///     client_mappings: a mapping of clients (by string name) to their server channel
-///         ends
 pub struct LocalUpdateServer<Req: PartialEq + Send + Clone,
                              Updt: PartialEq + Send + Clone,
                              Res: PartialEq + Send + Clone> {
@@ -48,14 +41,6 @@ impl<Req: PartialEq + Send + Clone,
      Updt: PartialEq + Send + Clone,
      Res: PartialEq + Send + Clone> LocalUpdateClient<Req, Updt, Res> {
     /// Creates a new LocalUpdateClient with given req_tx, updt_rx, and res_rx
-    /// 
-    /// Args:
-    ///     req_tx: the request transmitter
-    ///     updt_rx: the update receiver
-    ///     res_rx: the response receiver
-    /// 
-    /// Returns:
-    ///     Self: A new LocalUpdateClient
     pub const fn new(req_tx: Sender<Req>, updt_rx: Receiver<Updt>, res_rx: Receiver<Res>) -> Self {
         Self { req_tx, updt_rx, res_rx }
     }

--- a/src/update_client_server/local.rs
+++ b/src/update_client_server/local.rs
@@ -66,6 +66,14 @@ impl<Req: PartialEq + Send + Clone,
 
 impl<Req: PartialEq + Send + Clone,
      Updt: PartialEq + Send + Clone,
+     Res: PartialEq + Send + Clone> Default for LocalUpdateServer<Req, Updt, Res> {
+        fn default() -> Self {
+            Self::new()
+        }
+     }
+
+impl<Req: PartialEq + Send + Clone,
+     Updt: PartialEq + Send + Clone,
      Res: PartialEq + Send + Clone> UpdateClient<Req, Updt, Res, mpsc::SendError<Req>> for LocalUpdateClient<Req, Updt, Res> {
     fn send_request(&self, request: Req) -> Result<(), mpsc::SendError<Req>> {
         self.req_tx.send(request)
@@ -77,7 +85,7 @@ impl<Req: PartialEq + Send + Clone,
         if let Some(update) = iter.last() {
             return Some(update);
         }
-        return None;
+        None
     }
 
     fn receive_response(&self) -> Option<Res> {
@@ -86,7 +94,7 @@ impl<Req: PartialEq + Send + Clone,
         if let Some(response) = iter.last() {
             return Some(response);
         }
-        return None;
+        None
     }
 }
 
@@ -103,7 +111,7 @@ impl<Req: PartialEq + Send + Clone,
         let channels = LocalUpdateServerChannels::new(req_rx, updt_tx, res_tx);
         self.client_mappings.insert(client_name, channels);
 
-        return LocalUpdateClient::new(req_tx, updt_rx, res_rx);
+        LocalUpdateClient::new(req_tx, updt_rx, res_rx)
     }
 
     fn get_clients(&self) -> Vec<String> {
@@ -113,7 +121,7 @@ impl<Req: PartialEq + Send + Clone,
             clients.push(client.clone());
         }
 
-        return clients;
+        clients
     }
 
     fn receive_requests(&self) -> Vec<(String, Req)> {
@@ -126,18 +134,18 @@ impl<Req: PartialEq + Send + Clone,
             }
         }
 
-        return requests;
+        requests
     }
 
     fn send_update(&self, client: String, update: Updt) -> SendError<Updt> {
         if let Some(channels) = self.client_mappings.get(&client) {
             if let Err(send_err) = channels.updt_tx.send(update) {
-                return SendError::<Updt>::SendIncomplete((client, send_err));
+                SendError::<Updt>::SendIncomplete((client, send_err))
             } else {
-                return SendError::<Updt>::NoError(client);
+                SendError::<Updt>::NoError(client)
             }
         } else {
-            return SendError::<Updt>::ClientNotFound(client);
+            SendError::<Updt>::ClientNotFound(client)
         }
     }
 
@@ -156,18 +164,18 @@ impl<Req: PartialEq + Send + Clone,
             }
         }
 
-        return errors;
+        errors
     }
 
     fn send_response(&self, client: String, response: Res) -> SendError<Res> {
         if let Some(channels) = self.client_mappings.get(&client) {
             if let Err(send_err) = channels.res_tx.send(response) {
-                return SendError::<Res>::SendIncomplete((client, send_err));
+                SendError::<Res>::SendIncomplete((client, send_err))
             } else {
-                return SendError::<Res>::NoError(client);
+                SendError::<Res>::NoError(client)
             }
         } else {
-            return SendError::<Res>::ClientNotFound(client);
+            SendError::<Res>::ClientNotFound(client)
         }
     }
 
@@ -186,7 +194,7 @@ impl<Req: PartialEq + Send + Clone,
             }
         }
 
-        return errors;
+        errors
     }
 }
 


### PR DESCRIPTION
I realized that I didn't set up some of the docs right so for people trying to use NComm the documentation was definitely lacking.  So, this PR addresses that and also changes update rate to update delay.  I realized when going over the documentation that rate implies frequency (i.e. Hz) and I wanted a time (i.e. seconds).  Therefore, I switched update rate to update delay.