### PR TITLE
Make Publish Trait Require a Mutable Self Reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "ncomm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ctrlc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ncomm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "Rust Node-Based Communication Prototype Framework"

--- a/src/publisher_subscriber.rs
+++ b/src/publisher_subscriber.rs
@@ -14,7 +14,7 @@ pub trait Publish<Data: Send + Clone> {
     /// 
     /// Args:
     ///     data: the data to be sent
-    fn send(&self, data: Data);
+    fn send(&mut self, data: Data);
 }
 
 /// Trait for all Publishers that allows subscribers to subscribe to their

--- a/src/publisher_subscriber/local.rs
+++ b/src/publisher_subscriber/local.rs
@@ -35,7 +35,7 @@ impl<Data: Send + Clone> LocalPublisher<Data> {
 }
 
 impl<Data: Send + Clone> Publish<Data> for LocalPublisher<Data> {
-    fn send(&self, data: Data) {
+    fn send(&mut self, data: Data) {
         for tx in self.txs.iter() {
             tx.send(data.clone()).expect("Data Not Sendable");
         }

--- a/src/publisher_subscriber/udp.rs
+++ b/src/publisher_subscriber/udp.rs
@@ -58,7 +58,7 @@ impl<'a, Data: Send + Clone, const DATA_SIZE: usize>  UdpSubscriber<Data, DATA_S
 }
 
 impl<'a, Data: Send + Clone, const DATA_SIZE: usize> Publish<Data> for UdpPublisher<'a, Data, DATA_SIZE> {
-    fn send(&self, data: Data) {
+    fn send(&mut self, data: Data) {
         let buf: [u8; DATA_SIZE] = unsafe { std::mem::transmute_copy(&data) };
         for address in self.addresses.iter() {
             if let Err(err) = self.tx.send_to(&buf, address) {
@@ -113,7 +113,7 @@ mod tests {
     // Test that a udp publisher and subscriber can send data between each other.
     fn test_send_data_udp_publisher_and_subscriber() {
         let mut subscriber:  UdpSubscriber<u8, 1> =  UdpSubscriber::new("127.0.0.1:8001", Some("127.0.0.1:8000"));
-        let publisher: UdpPublisher<u8, 1> = UdpPublisher::new("127.0.0.1:8000", vec!["127.0.0.1:8001"]);
+        let mut publisher: UdpPublisher<u8, 1> = UdpPublisher::new("127.0.0.1:8000", vec!["127.0.0.1:8001"]);
 
         publisher.send(5u8);
 
@@ -129,7 +129,7 @@ mod tests {
     // Test that a udp publisher and subscriber can send multiple datas between each other.
     fn test_send_many_data_udp_publisher_and_subscriber() {
         let mut subscriber:  UdpSubscriber<u8, 1> =  UdpSubscriber::new("127.0.0.1:7001", Some("127.0.0.1:7000"));
-        let publisher: UdpPublisher<u8, 1> = UdpPublisher::new("127.0.0.1:7000", vec!["127.0.0.1:7001"]);
+        let mut publisher: UdpPublisher<u8, 1> = UdpPublisher::new("127.0.0.1:7000", vec!["127.0.0.1:7001"]);
 
         for i in 0..=8u8 {
             publisher.send(i);


### PR DESCRIPTION
I was making a radio publisher and realized it will be necessary for certain protocols that publish takes a mutable reference to self.