### PR TITLE
Mapped Subscribers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "ncomm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ctrlc",
  "packed_struct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ncomm"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "Rust Node-Based Communication Prototype Framework"

--- a/src/publisher_subscriber/udp.rs
+++ b/src/publisher_subscriber/udp.rs
@@ -4,7 +4,7 @@
 //! The UDP Publisher sends data as a UDP Datagram to some other Subscriber.
 //! 
 
-use std::net::UdpSocket;
+use std::{net::UdpSocket, collections::HashMap};
 use std::marker::PhantomData;
 
 use crate::publisher_subscriber::{Publish, SubscribeRemote, Receive};
@@ -37,6 +37,16 @@ pub struct  UdpSubscriber<Data: Send + Clone, const DATA_SIZE: usize> {
 pub struct BufferedUdpSubscriber<Data: Send + Clone, const DATA_SIZE: usize> {
     rx: UdpSocket,
     pub data: Vec<Data>,
+}
+
+/// Local Subscriber that stores data in a HashMap
+/// 
+/// The Hash function is used to map a reference to a piece of data to its corresponding key
+/// in the data HashMap.
+pub struct MappedUdpSubscriber<Data: Send + Clone, const DATA_SIZE: usize> {
+    rx: UdpSocket,
+    pub data: HashMap<u128, Data>,
+    hash: Box<dyn Fn(&Data) -> u128>,
 }
 
 impl<'a, Data: Send + Clone, const DATA_SIZE: usize> UdpPublisher<'a, Data, DATA_SIZE> {
@@ -82,6 +92,26 @@ impl<'a, Data: Send + Clone, const DATA_SIZE: usize> BufferedUdpSubscriber<Data,
     }
 }
 
+impl<'a, Data: Send + Clone, const DATA_SIZE: usize> MappedUdpSubscriber<Data, DATA_SIZE> {
+    /// Create a new MappedUdpSubscriber with a UdpSocket bound to the bind address listening to the
+    /// from address.
+    /// 
+    /// To only listen to communication on a specific address specify the from_address
+    pub fn new(bind_address: &'a str, from_address: Option<&'a str>, hash_function: Box<dyn Fn(&Data) -> u128>) -> Self {
+        let socket = UdpSocket::bind(bind_address).expect("couldn't bind to the given bind address");
+        if let Some(from_address) = from_address {
+            socket.connect(from_address).expect("couldn't connect to the given address");
+        }
+        socket.set_nonblocking(true).unwrap();
+
+        Self {
+            rx: socket,
+            data: HashMap::new(),
+            hash: hash_function,
+        }
+    }
+}
+
 impl<'a, Data: Send + Clone, const DATA_SIZE: usize> Publish<Data> for UdpPublisher<'a, Data, DATA_SIZE> {
     fn send(&mut self, data: Data) {
         let buf: [u8; DATA_SIZE] = unsafe { std::mem::transmute_copy(&data) };
@@ -121,6 +151,22 @@ impl<Data: Send + Clone, const DATA_SIZE: usize> Receive for BufferedUdpSubscrib
             let mut buf = [0u8; DATA_SIZE];
             match self.rx.recv(&mut buf) {
                 Ok(_received) => unsafe { self.data.push(std::mem::transmute_copy(&buf)); },
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+impl<Data: Send + Clone, const DATA_SIZE: usize> Receive for MappedUdpSubscriber<Data, DATA_SIZE> {
+    fn update_data(&mut self) {
+        loop {
+            let mut buf = [0u8; DATA_SIZE];
+            match self.rx.recv(&mut buf) {
+                Ok(_received) => {
+                    let data: Data = unsafe { std::mem::transmute_copy(&buf) };
+                    let label = (self.hash)(&data);
+                    self.data.insert(label, data);
+                },
                 Err(_) => break,
             }
         }


### PR DESCRIPTION
This PR outlines a new type of subscriber.  The mapped subscriber stores incoming data into a HashMap by mapping the incoming data to a key type.