### PR TITLE
Add IDs to Nodes

### DIFF
--- a/examples/minimal-client-server/src/main.rs
+++ b/examples/minimal-client-server/src/main.rs
@@ -20,6 +20,15 @@ use minimal_server::MinimalServer;
 pub mod minimal_client;
 use minimal_client::MinimalClient;
 
+/// An enum identifier or the two nodes
+#[derive(PartialEq)]
+pub enum NodeIdentifier {
+    /// The server node
+    ServerNode,
+    /// The client node
+    ClientNode,
+}
+
 /// A request that asks for the sum of two `u64`s.
 #[derive(Clone, Copy)]
 pub struct AddTwoIntsRequest {

--- a/examples/minimal-client-server/src/minimal_client.rs
+++ b/examples/minimal-client-server/src/minimal_client.rs
@@ -3,7 +3,7 @@
 //! containing the sum of the two `u64`s.
 //!
 
-use super::{AddTwoIntsRequest, AddTwoIntsResponse};
+use super::{AddTwoIntsRequest, AddTwoIntsResponse, NodeIdentifier};
 
 use ncomm_clients_and_servers::local::LocalClient;
 use ncomm_core::{Client, Node};
@@ -41,7 +41,11 @@ impl MinimalClient {
     }
 }
 
-impl Node for MinimalClient {
+impl Node<NodeIdentifier> for MinimalClient {
+    fn get_id(&self) -> NodeIdentifier {
+        NodeIdentifier::ClientNode
+    }
+
     fn get_update_delay_us(&self) -> u128 {
         500_000
     }

--- a/examples/minimal-client-server/src/minimal_server.rs
+++ b/examples/minimal-client-server/src/minimal_server.rs
@@ -3,7 +3,7 @@
 //! the wrapping sum of the two u64s.
 //!
 
-use super::{AddTwoIntsRequest, AddTwoIntsResponse};
+use super::{AddTwoIntsRequest, AddTwoIntsResponse, NodeIdentifier};
 
 use ncomm_clients_and_servers::local::{LocalClient, LocalServer};
 use ncomm_core::{Node, Server};
@@ -48,7 +48,11 @@ impl MinimalServer {
     }
 }
 
-impl Node for MinimalServer {
+impl Node<NodeIdentifier> for MinimalServer {
+    fn get_id(&self) -> NodeIdentifier {
+        NodeIdentifier::ServerNode
+    }
+
     fn get_update_delay_us(&self) -> u128 {
         500_000
     }

--- a/examples/minimal-publisher-subscriber/src/main.rs
+++ b/examples/minimal-publisher-subscriber/src/main.rs
@@ -21,6 +21,15 @@ use minimal_publisher::MinimalPublisher;
 pub mod minimal_subscriber;
 use minimal_subscriber::MinimalSubscriber;
 
+/// Identifier for the two nodes.
+#[derive(PartialEq)]
+pub enum NodeIdentifier {
+    /// The publisher node
+    PublisherNode,
+    /// The subscriber node
+    SubscriberNode,
+}
+
 fn main() {
     let mut publisher_node = MinimalPublisher::new();
     let subscriber_node = MinimalSubscriber::new(publisher_node.create_subscriber());

--- a/examples/minimal-publisher-subscriber/src/minimal_publisher.rs
+++ b/examples/minimal-publisher-subscriber/src/minimal_publisher.rs
@@ -3,6 +3,8 @@
 //! the message "Hello, World! {count}" to the subscriber.
 //!
 
+use super::NodeIdentifier;
+
 use ncomm_core::{Node, Publisher};
 use ncomm_publishers_and_subscribers::local::{LocalPublisher, LocalSubscriber};
 
@@ -36,7 +38,11 @@ impl MinimalPublisher {
     }
 }
 
-impl Node for MinimalPublisher {
+impl Node<NodeIdentifier> for MinimalPublisher {
+    fn get_id(&self) -> NodeIdentifier {
+        NodeIdentifier::PublisherNode
+    }
+
     fn get_update_delay_us(&self) -> u128 {
         500_000u128
     }

--- a/examples/minimal-publisher-subscriber/src/minimal_subscriber.rs
+++ b/examples/minimal-publisher-subscriber/src/minimal_subscriber.rs
@@ -3,6 +3,8 @@
 //! the publisher node.
 //!
 
+use super::NodeIdentifier;
+
 use ncomm_core::{Node, Subscriber};
 use ncomm_publishers_and_subscribers::local::LocalSubscriber;
 
@@ -27,7 +29,11 @@ impl MinimalSubscriber {
     }
 }
 
-impl Node for MinimalSubscriber {
+impl Node<NodeIdentifier> for MinimalSubscriber {
+    fn get_id(&self) -> NodeIdentifier {
+        NodeIdentifier::SubscriberNode
+    }
+
     fn get_update_delay_us(&self) -> u128 {
         500_000
     }

--- a/examples/minimal-update-client-server/src/fibonacci_update_client.rs
+++ b/examples/minimal-update-client-server/src/fibonacci_update_client.rs
@@ -3,7 +3,7 @@
 //! fibonacci series.
 //!
 
-use super::{FibonacciRequest, FibonacciResponse, FibonacciUpdate};
+use super::{FibonacciRequest, FibonacciResponse, FibonacciUpdate, NodeIdentifier};
 
 use ncomm_core::{Node, UpdateClient};
 use ncomm_update_clients_and_servers::local::LocalUpdateClient;
@@ -49,7 +49,11 @@ impl FibonacciUpdateClient {
     }
 }
 
-impl Node for FibonacciUpdateClient {
+impl Node<NodeIdentifier> for FibonacciUpdateClient {
+    fn get_id(&self) -> NodeIdentifier {
+        NodeIdentifier::FibonacciClient
+    }
+
     fn get_update_delay_us(&self) -> u128 {
         100_000
     }

--- a/examples/minimal-update-client-server/src/fibonacci_update_server.rs
+++ b/examples/minimal-update-client-server/src/fibonacci_update_server.rs
@@ -4,7 +4,7 @@
 //! into the series
 //!
 
-use super::{FibonacciRequest, FibonacciResponse, FibonacciUpdate};
+use super::{FibonacciRequest, FibonacciResponse, FibonacciUpdate, NodeIdentifier};
 
 use ncomm_core::{Node, UpdateServer};
 use ncomm_update_clients_and_servers::local::{LocalUpdateClient, LocalUpdateServer};
@@ -93,7 +93,11 @@ impl FibonacciUpdateServer {
     }
 }
 
-impl Node for FibonacciUpdateServer {
+impl Node<NodeIdentifier> for FibonacciUpdateServer {
+    fn get_id(&self) -> NodeIdentifier {
+        NodeIdentifier::FibonacciServer
+    }
+
     fn get_update_delay_us(&self) -> u128 {
         100_000
     }

--- a/examples/minimal-update-client-server/src/main.rs
+++ b/examples/minimal-update-client-server/src/main.rs
@@ -19,6 +19,15 @@ use fibonacci_update_client::FibonacciUpdateClient;
 pub mod fibonacci_update_server;
 use fibonacci_update_server::FibonacciUpdateServer;
 
+#[derive(PartialEq)]
+/// An identifier for the fibonacci client and server
+pub enum NodeIdentifier {
+    /// The fibonacci client
+    FibonacciClient,
+    /// The fibonacci server
+    FibonacciServer,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// A request asking for a the nth order of the fibonacci sequence.
 pub struct FibonacciRequest {

--- a/ncomm-core/src/executor.rs
+++ b/ncomm-core/src/executor.rs
@@ -27,7 +27,10 @@ pub enum ExecutorState {
 }
 
 /// An executor handles the scheduling and execution of nodes
-pub trait Executor {
+///
+/// All nodes should have some unique ID that makes them identifiable
+/// as trait objects
+pub trait Executor<ID: PartialEq> {
     /// Starts the nodes contained by the executor
     fn start(&mut self);
 
@@ -43,13 +46,16 @@ pub trait Executor {
     fn check_interrupt(&mut self) -> bool;
 
     /// Add a node to the executor.
-    fn add_node(&mut self, node: Box<dyn Node>);
+    fn add_node(&mut self, node: Box<dyn Node<ID>>);
 
     /// Add a node to the executor with some given context.
     ///
     /// Note: The context is mainly to allow for extra configuration when
     /// adding nodes.
-    fn add_node_with_context<CTX>(&mut self, node: Box<dyn Node>, _ctx: CTX) {
+    fn add_node_with_context<CTX>(&mut self, node: Box<dyn Node<ID>>, _ctx: CTX) {
         self.add_node(node);
     }
+
+    /// Remove a node from the executor.
+    fn remove_node(&mut self, id: &ID) -> Option<Box<dyn Node<ID>>>;
 }

--- a/ncomm-core/src/node.rs
+++ b/ncomm-core/src/node.rs
@@ -11,7 +11,13 @@
 
 /// A Node represents a singular process that performs some singular
 /// purpose
-pub trait Node: Send {
+///
+/// Nodes should also all be given unique IDs so that they can be identified as
+/// trait objects.
+pub trait Node<ID: PartialEq>: Send {
+    /// Return the node's ID
+    fn get_id(&self) -> ID;
+
     /// Return the node's update rate (in us)
     fn get_update_delay_us(&self) -> u128;
 

--- a/ncomm-executors/src/lib.rs
+++ b/ncomm-executors/src/lib.rs
@@ -29,32 +29,39 @@ use std::cmp::{Ord, Ordering};
 /// of their next update.
 ///
 /// This ensures that nodes are updated at the correct time
-pub(crate) struct NodeWrapper {
+pub(crate) struct NodeWrapper<ID: PartialEq> {
     /// The timestamp of the nodes next update
     pub priority: u128,
     /// The nde this NodeWrapper is wrapping around
-    pub node: Box<dyn Node>,
+    pub node: Box<dyn Node<ID>>,
 }
 
-impl Ord for NodeWrapper {
+impl<ID: PartialEq> NodeWrapper<ID> {
+    /// Destroy the node wrapper returning the node it was wrapping.
+    pub fn destroy(self) -> Box<dyn Node<ID>> {
+        self.node
+    }
+}
+
+impl<ID: PartialEq> Ord for NodeWrapper<ID> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.priority.cmp(&other.priority).reverse()
     }
 }
 
-impl PartialOrd for NodeWrapper {
+impl<ID: PartialEq> PartialOrd for NodeWrapper<ID> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl PartialEq for NodeWrapper {
+impl<ID: PartialEq> PartialEq for NodeWrapper<ID> {
     fn eq(&self, other: &Self) -> bool {
         self.priority == other.priority
     }
 }
 
-impl Eq for NodeWrapper {}
+impl<ID: PartialEq> Eq for NodeWrapper<ID> {}
 
 /// This method performs binary search insertion into the sorted vector
 /// `vec` with the node `node`.
@@ -62,7 +69,7 @@ impl Eq for NodeWrapper {}
 /// This is just a convenience method I found myself using a ton so I decided
 /// to make it its own method.
 #[inline(always)]
-pub(crate) fn insert_into(vec: &mut Vec<NodeWrapper>, node: NodeWrapper) {
+pub(crate) fn insert_into<ID: PartialEq>(vec: &mut Vec<NodeWrapper<ID>>, node: NodeWrapper<ID>) {
     // If another node is found with the same priority, insert the node after that
     // node.  Otherwise, insert the node into the position it should be in in the
     // sorted vector


### PR DESCRIPTION
I realized it would probably be useful to be able to both identify Nodes and remove nodes from executors.  This PR adds an ID method to the Node trait so that Nodes are uniquely identifiable.