### PR TITLE
Add Serial Publisher/Subscriber + Client/Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,6 +1551,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,6 +2835,7 @@ name = "ncomm-clients-and-servers"
 version = "1.0.0"
 dependencies = [
  "crossbeam",
+ "embedded-io",
  "ncomm-core",
  "ncomm-utils",
  "rand",
@@ -2864,6 +2871,7 @@ name = "ncomm-publishers-and-subscribers"
 version = "1.0.0"
 dependencies = [
  "crossbeam",
+ "embedded-io",
  "ncomm-core",
  "ncomm-utils",
  "quanta",
@@ -2876,6 +2884,7 @@ name = "ncomm-update-clients-and-servers"
 version = "1.0.0"
 dependencies = [
  "crossbeam",
+ "embedded-io",
  "ncomm-core",
  "ncomm-utils",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,14 @@ categories = ["science::robotics"]
 
 [workspace.dependencies]
 # NComm
-ncomm = { path = "ncomm", version = "1.0.0" }
-ncomm-core = { path = "ncomm-core", version = "1.0.0" }
-ncomm-utils = { path = "ncomm-utils", version = "1.0.0" }
-ncomm-executors = { path = "ncomm-executors", version = "1.0.0" }
-ncomm-publishers-and-subscribers = { path = "ncomm-publishers-and-subscribers", version = "1.0.0" }
-ncomm-clients-and-servers = { path = "ncomm-clients-and-servers", version = "1.0.0" }
-ncomm-update-clients-and-servers = { path = "ncomm-update-clients-and-servers", version = "1.0.0" }
-ncomm-nodes = { path = "ncomm-nodes", version = "1.0.0" }
+ncomm = { path = "ncomm", version = "1.0.0", default-features = false }
+ncomm-core = { path = "ncomm-core", version = "1.0.0", default-features = false }
+ncomm-utils = { path = "ncomm-utils", version = "1.0.0", default-features = false }
+ncomm-executors = { path = "ncomm-executors", version = "1.0.0", default-features = false }
+ncomm-publishers-and-subscribers = { path = "ncomm-publishers-and-subscribers", version = "1.0.0", default-features = false }
+ncomm-clients-and-servers = { path = "ncomm-clients-and-servers", version = "1.0.0", default-features = false }
+ncomm-update-clients-and-servers = { path = "ncomm-update-clients-and-servers", version = "1.0.0", default-features = false }
+ncomm-nodes = { path = "ncomm-nodes", version = "1.0.0", default-features = false }
 
 # Outside Dependencies
 crossbeam = "0.8.4"
@@ -59,3 +59,4 @@ rand_distr = "0.4.3"
 rerun = "0.18.2"
 re_web_viewer_server = "0.18.2"
 re_ws_comms = "0.18.2"
+embedded-io = "0.6.1"

--- a/ncomm-clients-and-servers/Cargo.toml
+++ b/ncomm-clients-and-servers/Cargo.toml
@@ -11,9 +11,16 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-crossbeam = { workspace = true }
-ncomm-core = { workspace = true }
-ncomm-utils = { workspace = true }
+crossbeam = { workspace = true, optional = true }
+ncomm-core = { workspace = true, default-features = false }
+ncomm-utils = { workspace = true, default-features = false }
+embedded-io = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+
+[features]
+default = ["std"]
+nostd = ["ncomm-core/nostd", "ncomm-utils/nostd"]
+alloc = ["nostd", "ncomm-core/alloc", "ncomm-utils/alloc"]
+std = ["dep:crossbeam", "ncomm-core/std", "ncomm-utils/std"]

--- a/ncomm-clients-and-servers/src/lib.rs
+++ b/ncomm-clients-and-servers/src/lib.rs
@@ -7,7 +7,14 @@
 //!
 
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
+#[cfg(feature = "std")]
 pub mod local;
 
+#[cfg(feature = "std")]
 pub mod udp;
+
+pub mod serial;

--- a/ncomm-clients-and-servers/src/serial.rs
+++ b/ncomm-clients-and-servers/src/serial.rs
@@ -1,0 +1,255 @@
+//!
+//! Serial Client and Server for communication using embedded-io
+//! traits.
+//!
+
+use core::marker::PhantomData;
+
+use embedded_io::{Error, Read, ReadReady, Write};
+
+use ncomm_core::client_server::{Client, Server};
+use ncomm_utils::packing::{Packable, PackingError};
+
+/// An Error regarding sending and receiving data via serial
+#[derive(Debug)]
+pub enum SerialClientServerError<Err: Error> {
+    /// Embedded-IO Error
+    IOError(Err),
+    /// An error occurred with pacing the data
+    PackingError(PackingError),
+}
+
+/// Client that sends requests and receives responses via a serial device.
+///
+/// Note: To make this client no_std compatible the client has an internal buffer
+/// that is statically allocated, hence the reason for the const BUFFER_SIZE: usize
+/// generic
+pub struct SerialClient<
+    Req: Packable,
+    Res: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err> + Write<Error = Err>,
+    Err: Error,
+    const BUFFER_SIZE: usize,
+> {
+    /// The serial peripheral device
+    serial_device: Serial,
+    /// The internal buffer for encoding data
+    buffer: [u8; BUFFER_SIZE],
+    /// A marker t bind the type of data
+    _phantom: PhantomData<(Req, Res)>,
+}
+
+impl<Req, Res, Serial, Err, const BUFFER_SIZE: usize>
+    SerialClient<Req, Res, Serial, Err, BUFFER_SIZE>
+where
+    Req: Packable,
+    Res: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err> + Write<Error = Err>,
+    Err: Error,
+{
+    /// Construct a new SerialClient from a serial peripheral
+    pub fn new(serial_device: Serial, buffer: [u8; BUFFER_SIZE]) -> Self {
+        assert!(
+            BUFFER_SIZE >= Req::len() + Res::len(),
+            "The buffer must be large enough to fit a request and response"
+        );
+        Self {
+            serial_device,
+            buffer,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Destroy the SerialClient, returning the serial peripheral
+    pub fn destroy(self) -> Serial {
+        self.serial_device
+    }
+}
+
+impl<Req, Res, Serial, Err, const BUFFER_SIZE: usize> Client
+    for SerialClient<Req, Res, Serial, Err, BUFFER_SIZE>
+where
+    Req: Packable,
+    Res: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err> + Write<Error = Err>,
+    Err: Error,
+{
+    type Request = Req;
+    type Response = Res;
+    type Error = SerialClientServerError<Err>;
+
+    fn send_request(&mut self, request: Self::Request) -> Result<(), Self::Error> {
+        self.buffer.iter_mut().for_each(|v| *v = 0);
+        request
+            .pack(&mut self.buffer)
+            .map_err(SerialClientServerError::PackingError)?;
+
+        self.serial_device
+            .write_all(&self.buffer[..Req::len()])
+            .map_err(SerialClientServerError::IOError)?;
+
+        Ok(())
+    }
+
+    fn poll_for_response(
+        &mut self,
+    ) -> Result<Option<(Self::Request, Self::Response)>, Self::Error> {
+        if let Ok(ready) = self.serial_device.read_ready() {
+            if !ready {
+                return Ok(None);
+            }
+
+            self.buffer.iter_mut().for_each(|v| *v = 0);
+            if self.serial_device.read(&mut self.buffer).is_ok() {
+                if let (Ok(request), Ok(response)) = (
+                    Req::unpack(&self.buffer[..Req::len()]),
+                    Res::unpack(&self.buffer[Req::len()..]),
+                ) {
+                    return Ok(Some((request, response)));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    #[cfg(any(feature = "alloc", feature = "std"))]
+    fn poll_for_responses(&mut self) -> Vec<Result<(Self::Request, Self::Response), Self::Error>> {
+        let mut responses = Vec::new();
+
+        while let Ok(ready) = self.serial_device.read_ready() {
+            if !ready {
+                break;
+            }
+
+            self.buffer.iter_mut().for_each(|v| *v = 0);
+            if self.serial_device.read(&mut self.buffer).is_ok() {
+                if let (Ok(request), Ok(response)) = (
+                    Req::unpack(&self.buffer[..Req::len()]),
+                    Res::unpack(&self.buffer[Req::len()..]),
+                ) {
+                    responses.push(Ok((request, response)));
+                }
+            }
+        }
+
+        responses
+    }
+}
+
+/// A serial server capable of receiving requests and sending responses.
+///
+/// Note: To make this server no_std compatible the server has an internal buffer
+/// that is statically allocated, hence the reason for the const BUFFER_SIZE: usize
+/// generic
+pub struct SerialServer<
+    Req: Packable,
+    Res: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err> + Write<Error = Err>,
+    Err: Error,
+    const BUFFER_SIZE: usize,
+> {
+    /// The serial peripheral device
+    serial_device: Serial,
+    /// The internal buffer for sending and receiving data
+    buffer: [u8; BUFFER_SIZE],
+    /// A holder for the request and response data type
+    _phantom: PhantomData<(Req, Res)>,
+}
+
+impl<Req, Res, Serial, Err, const BUFFER_SIZE: usize>
+    SerialServer<Req, Res, Serial, Err, BUFFER_SIZE>
+where
+    Req: Packable,
+    Res: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err> + Write<Error = Err>,
+    Err: Error,
+{
+    /// Create a new SerialServer from a serial device peripheral
+    pub fn new(serial_device: Serial, buffer: [u8; BUFFER_SIZE]) -> Self {
+        assert!(
+            buffer.len() >= Req::len() + Res::len(),
+            "The buffer must be large enough to accommodate a request and response"
+        );
+        Self {
+            serial_device,
+            buffer,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Destroy the SerialServer returning the serial peripheral
+    pub fn destroy(self) -> Serial {
+        self.serial_device
+    }
+}
+
+impl<Req, Res, Serial, Err, const BUFFER_SIZE: usize> Server
+    for SerialServer<Req, Res, Serial, Err, BUFFER_SIZE>
+where
+    Req: Packable,
+    Res: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err> + Write<Error = Err>,
+    Err: Error,
+{
+    type Request = Req;
+    type Response = Res;
+    type Key = bool;
+    type Error = SerialClientServerError<Err>;
+
+    fn poll_for_request(&mut self) -> Result<Option<(Self::Key, Self::Request)>, Self::Error> {
+        if let Ok(ready) = self.serial_device.read_ready() {
+            if !ready {
+                return Ok(None);
+            }
+
+            self.buffer.iter_mut().for_each(|v| *v = 0);
+            if self.serial_device.read(&mut self.buffer).is_ok() {
+                if let Ok(request) = Req::unpack(&self.buffer[..Req::len()]) {
+                    return Ok(Some((true, request)));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    #[cfg(any(feature = "alloc", feature = "std"))]
+    fn poll_for_requests(&mut self) -> Vec<Result<(Self::Key, Self::Request), Self::Error>> {
+        let mut requests = Vec::new();
+
+        while let Ok(ready) = self.serial_device.read_ready() {
+            if !ready {
+                break;
+            }
+
+            self.buffer.iter_mut().for_each(|v| *v = 0);
+            if self.serial_device.read(&mut self.buffer).is_ok() {
+                if let Ok(request) = Req::unpack(&self.buffer[..Req::len()]) {
+                    requests.push(Ok((true, request)));
+                }
+            }
+        }
+
+        requests
+    }
+
+    fn send_response(
+        &mut self,
+        _client_key: Self::Key,
+        request: Self::Request,
+        response: Self::Response,
+    ) -> Result<(), Self::Error> {
+        self.buffer.iter_mut().for_each(|v| *v = 0);
+        request
+            .pack(&mut self.buffer[..Req::len()])
+            .map_err(SerialClientServerError::PackingError)?;
+        response
+            .pack(&mut self.buffer[Req::len()..])
+            .map_err(SerialClientServerError::PackingError)?;
+
+        self.serial_device
+            .write_all(&self.buffer[..(Req::len() + Res::len())])
+            .map_err(SerialClientServerError::IOError)?;
+
+        Ok(())
+    }
+}

--- a/ncomm-clients-and-servers/src/udp.rs
+++ b/ncomm-clients-and-servers/src/udp.rs
@@ -23,7 +23,7 @@ pub enum UdpClientServerError<Data: Packable> {
     /// An error with packing the data
     PackingError(PackingError),
     /// Request from an unknown client
-    UnknownRequester(Data),
+    UnknownRequester((Data, SocketAddr)),
     /// The client you are sending data to is unknown
     UnknownClient,
 }
@@ -71,6 +71,25 @@ impl<Req: Packable, Res: Packable> Client for UdpClient<Req, Res> {
         Ok(())
     }
 
+    fn poll_for_response(
+        &mut self,
+    ) -> Result<Option<(Self::Request, Self::Response)>, Self::Error> {
+        let mut buffer = vec![0u8; Req::len() + Res::len()];
+        let (req, res) = match self.socket.recv(&mut buffer) {
+            Ok(_received) => (
+                Req::unpack(&buffer[..Req::len()]),
+                Res::unpack(&buffer[Req::len()..]),
+            ),
+            Err(_) => return Ok(None),
+        };
+
+        if let (Ok(req), Ok(res)) = (req, res) {
+            Ok(Some((req, res)))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Check the UDP socket for incoming Datagrams.
     ///
     /// Note: Incoming data will be in the form:
@@ -78,7 +97,7 @@ impl<Req: Packable, Res: Packable> Client for UdpClient<Req, Res> {
     fn poll_for_responses(&mut self) -> Vec<Result<(Self::Request, Self::Response), Self::Error>> {
         let mut responses = Vec::new();
 
-        let mut buffer = vec![0u8; Res::len() + Res::len()];
+        let mut buffer = vec![0u8; Req::len() + Res::len()];
         loop {
             let (req, res) = match self.socket.recv(&mut buffer) {
                 Ok(_received) => (
@@ -151,6 +170,25 @@ impl<Req: Packable, Res: Packable, K: Eq + Clone> Server for UdpServer<Req, Res,
     type Key = K;
     type Error = UdpClientServerError<Req>;
 
+    fn poll_for_request(&mut self) -> Result<Option<(Self::Key, Self::Request)>, Self::Error> {
+        let mut buffer = vec![0u8; Req::len()];
+        let address = match self.socket.recv_from(&mut buffer) {
+            Ok((_request_size, address)) => address,
+            Err(_) => return Ok(None),
+        };
+
+        match Req::unpack(&buffer[..]) {
+            Ok(data) => {
+                if let Some((k, _)) = self.client_addresses.iter().find(|v| v.1 == address) {
+                    Ok(Some((k.clone(), data)))
+                } else {
+                    Err(UdpClientServerError::UnknownRequester((data, address)))
+                }
+            }
+            Err(err) => Err(UdpClientServerError::PackingError(err)),
+        }
+    }
+
     fn poll_for_requests(&mut self) -> Vec<Result<(Self::Key, Self::Request), Self::Error>> {
         let mut requests = Vec::new();
 
@@ -166,7 +204,7 @@ impl<Req: Packable, Res: Packable, K: Eq + Clone> Server for UdpServer<Req, Res,
                     if let Some((k, _)) = self.client_addresses.iter().find(|v| v.1 == address) {
                         requests.push(Ok((k.clone(), data)));
                     } else {
-                        requests.push(Err(UdpClientServerError::UnknownRequester(data)));
+                        requests.push(Err(UdpClientServerError::UnknownRequester((data, address))));
                     }
                 }
                 Err(err) => requests.push(Err(UdpClientServerError::PackingError(err))),
@@ -354,6 +392,48 @@ mod tests {
             let response = response.unwrap();
             assert_eq!(response.0, client_two_request);
             assert_eq!(response.1, client_two_response);
+        }
+    }
+
+    #[test]
+    fn test_udp_client_server_singular_send() {
+        let mut server: UdpServer<Request, Response, i32> = UdpServer::new_with(
+            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 7005)),
+            vec![(
+                0,
+                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 7006)),
+            )],
+        )
+        .unwrap();
+
+        let mut client_one: UdpClient<Request, Response> = UdpClient::new(
+            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 7006)),
+            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 7005)),
+        )
+        .unwrap();
+
+        let client_one_request = Request::new();
+        let client_one_response = Response::new(client_one_request.clone());
+
+        client_one.send_request(client_one_request).unwrap();
+
+        sleep(Duration::from_millis(50));
+
+        if let Ok(Some((k, request))) = server.poll_for_request() {
+            server
+                .send_response(k, request, client_one_response.clone())
+                .unwrap();
+        } else {
+            assert!(false, "Expected to receive request");
+        }
+
+        sleep(Duration::from_millis(50));
+
+        if let Ok(Some((request, response))) = client_one.poll_for_response() {
+            assert_eq!(request, client_one_request);
+            assert_eq!(response, client_one_response);
+        } else {
+            assert!(false, "Expected to receive response");
         }
     }
 }

--- a/ncomm-core/Cargo.toml
+++ b/ncomm-core/Cargo.toml
@@ -11,3 +11,9 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+
+[features]
+default = ["std"]
+nostd = []
+alloc = ["nostd"]
+std = []

--- a/ncomm-core/src/client_server.rs
+++ b/ncomm-core/src/client_server.rs
@@ -5,6 +5,11 @@
 //! that request something from them (in the form of a request).
 //!
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 /// A common abstraction for all NComm clients to allow for the creation
 /// of a common method of sending requests and receiving responses.
 pub trait Client {
@@ -19,6 +24,13 @@ pub trait Client {
     /// Send a request to the server this client is associated with
     fn send_request(&mut self, request: Self::Request) -> Result<(), Self::Error>;
 
+    /// Check for a singular response from the server containing the request and response
+    /// from the server
+    #[allow(clippy::type_complexity)]
+    fn poll_for_response(&mut self)
+        -> Result<Option<(Self::Request, Self::Response)>, Self::Error>;
+
+    #[cfg(any(feature = "alloc", feature = "std"))]
     /// Check for a response from the server containing both the sent
     /// request and the response from the server
     #[allow(clippy::type_complexity)]
@@ -38,6 +50,11 @@ pub trait Server {
     /// the client
     type Error;
 
+    /// Check for an incoming request from the client
+    #[allow(clippy::type_complexity)]
+    fn poll_for_request(&mut self) -> Result<Option<(Self::Key, Self::Request)>, Self::Error>;
+
+    #[cfg(any(feature = "alloc", feature = "std"))]
     /// Check for incoming requests from the client
     #[allow(clippy::type_complexity)]
     fn poll_for_requests(&mut self) -> Vec<Result<(Self::Key, Self::Request), Self::Error>>;
@@ -50,6 +67,7 @@ pub trait Server {
         response: Self::Response,
     ) -> Result<(), Self::Error>;
 
+    #[cfg(any(feature = "alloc", feature = "std"))]
     /// Send a collection of responses to specified clients
     fn send_responses(
         &mut self,

--- a/ncomm-core/src/executor.rs
+++ b/ncomm-core/src/executor.rs
@@ -9,6 +9,11 @@
 
 use crate::node::Node;
 
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+#[cfg(feature = "std")]
+use std::boxed::Box;
+
 /// The current state an executor is in.
 ///
 /// This should be taken into account whenever the start or update methods

--- a/ncomm-core/src/lib.rs
+++ b/ncomm-core/src/lib.rs
@@ -5,11 +5,16 @@
 
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub mod node;
 pub use node::Node;
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 pub mod executor;
+#[cfg(any(feature = "std", feature = "alloc"))]
 pub use executor::{Executor, ExecutorState};
 
 pub mod publisher_subscriber;

--- a/ncomm-core/src/update_client_server.rs
+++ b/ncomm-core/src/update_client_server.rs
@@ -6,6 +6,11 @@
 //! update the client on.
 //!
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 /// A common abstraction for all NComm update clients
 pub trait UpdateClient {
     /// The type of data used as a request by the client
@@ -22,10 +27,21 @@ pub trait UpdateClient {
     #[allow(clippy::type_complexity)]
     fn send_request(&mut self, request: Self::Request) -> Result<(), Self::Error>;
 
+    /// Poll for a singular update from the server
+    #[allow(clippy::type_complexity)]
+    fn poll_for_update(&mut self) -> Result<Option<(Self::Request, Self::Update)>, Self::Error>;
+
+    #[cfg(any(feature = "alloc", feature = "std"))]
     /// Poll for updates from the server
     #[allow(clippy::type_complexity)]
     fn poll_for_updates(&mut self) -> Vec<Result<(Self::Request, Self::Update), Self::Error>>;
 
+    /// Poll for a singular response from the server
+    #[allow(clippy::type_complexity)]
+    fn poll_for_response(&mut self)
+        -> Result<Option<(Self::Request, Self::Response)>, Self::Error>;
+
+    #[cfg(any(feature = "alloc", feature = "std"))]
     /// Poll for responses from the server
     #[allow(clippy::type_complexity)]
     fn poll_for_responses(&mut self) -> Vec<Result<(Self::Request, Self::Response), Self::Error>>;
@@ -45,6 +61,11 @@ pub trait UpdateServer {
     /// to the update client
     type Error;
 
+    /// Check for a singular incoming request from the client
+    #[allow(clippy::type_complexity)]
+    fn poll_for_request(&mut self) -> Result<Option<(Self::Key, Self::Request)>, Self::Error>;
+
+    #[cfg(any(feature = "alloc", feature = "std"))]
     /// Check for incoming requests from the client
     #[allow(clippy::type_complexity)]
     fn poll_for_requests(&mut self) -> Vec<Result<(Self::Key, Self::Request), Self::Error>>;

--- a/ncomm-executors/Cargo.toml
+++ b/ncomm-executors/Cargo.toml
@@ -11,7 +11,13 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-crossbeam = { workspace = true }
-ncomm-core = { workspace = true }
-quanta = { workspace = true }
-threadpool = { workspace = true }
+crossbeam = { workspace = true, optional = true }
+ncomm-core = { workspace = true, default-features = false }
+quanta = { workspace = true, optional = true }
+threadpool = { workspace = true, optional = true }
+
+[features]
+default = ["std"]
+nostd = ["ncomm-core/nostd"]
+alloc = ["nostd", "ncomm-core/alloc"]
+std = ["ncomm-core/std", "dep:crossbeam", "dep:quanta", "dep:threadpool"]

--- a/ncomm-executors/src/lib.rs
+++ b/ncomm-executors/src/lib.rs
@@ -15,18 +15,34 @@
 // To test the internal state of nodes, they need to be force
 // downcasted into their respective type.
 #![cfg_attr(test, feature(downcast_unchecked))]
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
+#[cfg(feature = "std")]
 pub mod simple_executor;
+#[cfg(feature = "std")]
 pub use simple_executor::SimpleExecutor;
 
+#[cfg(feature = "std")]
 pub mod threadpool_executor;
+#[cfg(feature = "std")]
 pub use threadpool_executor::ThreadPoolExecutor;
 
+#[cfg(feature = "std")]
 pub mod threaded_executor;
+#[cfg(feature = "std")]
+pub use threaded_executor::ThreadedExecutor;
 
+use core::cmp::{Ord, Ordering};
 use ncomm_core::node::Node;
-use std::cmp::{Ord, Ordering};
 
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, vec::Vec};
+#[cfg(feature = "std")]
+use std::{boxed::Box, vec::Vec};
+
+#[cfg(any(feature = "alloc", feature = "std"))]
 /// The NodeWrapper wraps nodes giving them a priority based on the timestamp
 /// of their next update.
 ///
@@ -38,6 +54,7 @@ pub(crate) struct NodeWrapper<ID: PartialEq> {
     pub node: Box<dyn Node<ID>>,
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl<ID: PartialEq> NodeWrapper<ID> {
     /// Destroy the node wrapper returning the node it was wrapping.
     pub fn destroy(self) -> Box<dyn Node<ID>> {
@@ -45,26 +62,31 @@ impl<ID: PartialEq> NodeWrapper<ID> {
     }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl<ID: PartialEq> Ord for NodeWrapper<ID> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.priority.cmp(&other.priority).reverse()
     }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl<ID: PartialEq> PartialOrd for NodeWrapper<ID> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl<ID: PartialEq> PartialEq for NodeWrapper<ID> {
     fn eq(&self, other: &Self) -> bool {
         self.priority == other.priority
     }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl<ID: PartialEq> Eq for NodeWrapper<ID> {}
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 /// This method performs binary search insertion into the sorted vector
 /// `vec` with the node `node`.
 ///

--- a/ncomm-executors/src/threaded_executor.rs
+++ b/ncomm-executors/src/threaded_executor.rs
@@ -602,7 +602,7 @@ mod tests {
         }
 
         assert!(Duration::from_millis(95) < end - start);
-        assert!(end - start < Duration::from_millis(120));
+        assert!(end - start < Duration::from_millis(150));
     }
 
     #[test]

--- a/ncomm-nodes/Cargo.toml
+++ b/ncomm-nodes/Cargo.toml
@@ -15,10 +15,13 @@ categories.workspace = true
 rerun = { workspace = true, optional = true }
 re_web_viewer_server = { workspace = true, optional = true }
 re_ws_comms = { workspace = true, optional = true }
-ncomm-core = { workspace = true }
-ncomm-publishers-and-subscribers = { workspace = true }
+ncomm-core = { workspace = true, default-features = false }
+ncomm-publishers-and-subscribers = { workspace = true, default-features = false }
 
 [features]
-default = []
-rerun = ["dep:rerun", "ncomm-publishers-and-subscribers/rerun"]
-rerun-web-viewer = ["rerun", "rerun/web_viewer", "dep:re_web_viewer_server", "dep:re_ws_comms"]
+default = ["std"]
+nostd = ["ncomm-core/nostd", "ncomm-publishers-and-subscribers/nostd"]
+alloc = ["nostd", "ncomm-core/alloc", "ncomm-publishers-and-subscribers/alloc"]
+std = ["ncomm-core/std", "ncomm-publishers-and-subscribers/std"]
+rerun = ["std", "dep:rerun", "ncomm-publishers-and-subscribers/rerun"]
+rerun-web-viewer = ["std", "rerun", "rerun/web_viewer", "dep:re_web_viewer_server", "dep:re_ws_comms"]

--- a/ncomm-nodes/src/lib.rs
+++ b/ncomm-nodes/src/lib.rs
@@ -3,6 +3,10 @@
 //! tools.
 //!
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 #[deny(missing_docs)]
 #[cfg(feature = "rerun")]
 pub mod rerun;

--- a/ncomm-publishers-and-subscribers/Cargo.toml
+++ b/ncomm-publishers-and-subscribers/Cargo.toml
@@ -12,14 +12,18 @@ repository.workspace = true
 
 [dependencies]
 crossbeam = { workspace = true }
-ncomm-core = { workspace = true }
-ncomm-utils = { workspace = true }
+ncomm-core = { workspace = true, default-features = false }
+ncomm-utils = { workspace = true, default-features = false }
 quanta = { workspace = true }
 rerun = { workspace = true, optional = true }
+embedded-io = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
 
 [features]
-default = []
-rerun = ["dep:rerun"]
+default = ["std"]
+nostd = ["ncomm-core/nostd", "ncomm-utils/nostd"]
+alloc = ["nostd", "ncomm-core/alloc", "ncomm-utils/alloc"]
+std = ["ncomm-core/std", "ncomm-utils/std"]
+rerun = ["std", "dep:rerun"]

--- a/ncomm-publishers-and-subscribers/src/lib.rs
+++ b/ncomm-publishers-and-subscribers/src/lib.rs
@@ -7,10 +7,17 @@
 //!
 
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
+#[cfg(feature = "std")]
 pub mod local;
 
+#[cfg(feature = "std")]
 pub mod udp;
 
 #[cfg(feature = "rerun")]
 pub mod rerun;
+
+pub mod serial;

--- a/ncomm-publishers-and-subscribers/src/serial.rs
+++ b/ncomm-publishers-and-subscribers/src/serial.rs
@@ -1,0 +1,269 @@
+//!
+//! NComm Publisher and Subscriber for publishing over Serial using the embedded-io traits.
+//!
+//! This publisher and subscriber send and receive data over the serial
+//! peripherals of whatever system is being utilized.
+//!
+
+use core::marker::PhantomData;
+
+use embedded_io::{Error, Read, ReadReady, Write};
+
+use ncomm_core::publisher_subscriber::{Publisher, Subscriber};
+use ncomm_utils::packing::{Packable, PackingError};
+
+/// An Error regarding publishing serial data
+#[derive(Debug)]
+pub enum SerialPublishError<Err: Error> {
+    /// Embedded-IO Error
+    IOError(Err),
+    /// An error occurred with packing the data
+    PackingError(PackingError),
+}
+
+/// Publisher that publishes data via a serial device.
+///
+/// To make this publisher no_std compatible the publisher has an internal buffer
+/// that is statically allocated, hence the reason for the const BUFFER_SIZE: usize
+/// generic
+pub struct SerialPublisher<
+    Data: Packable,
+    Serial: Write<Error = Err>,
+    Err: Error,
+    const BUFFER_SIZE: usize,
+> {
+    /// The serial peripheral device
+    serial_device: Serial,
+    /// The internal buffer for encoding data
+    buffer: [u8; BUFFER_SIZE],
+    /// A marker to bind the type of data published to the publisher
+    _phantom: PhantomData<Data>,
+}
+
+impl<Data, Serial, Err, const BUFFER_SIZE: usize> SerialPublisher<Data, Serial, Err, BUFFER_SIZE>
+where
+    Data: Packable,
+    Serial: Write<Error = Err>,
+    Err: Error,
+{
+    /// Create a new SerialPublisher from the peripheral
+    pub fn new(serial_device: Serial, buffer: [u8; BUFFER_SIZE]) -> Self {
+        assert!(
+            BUFFER_SIZE >= Data::len(),
+            "The buffer must be large enough to fit encoded data"
+        );
+        Self {
+            serial_device,
+            buffer,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Destroy the SerialPublisher returning the serial peripheral
+    pub fn destroy(self) -> Serial {
+        self.serial_device
+    }
+}
+
+impl<Data, Serial, Err, const BUFFER_SIZE: usize> Publisher
+    for SerialPublisher<Data, Serial, Err, BUFFER_SIZE>
+where
+    Data: Packable,
+    Serial: Write<Error = Err>,
+    Err: Error,
+{
+    type Data = Data;
+    type Error = SerialPublishError<Err>;
+
+    fn publish(&mut self, data: Self::Data) -> Result<(), Self::Error> {
+        self.buffer.iter_mut().for_each(|v| *v = 0);
+        data.pack(&mut self.buffer)
+            .map_err(SerialPublishError::PackingError)?;
+
+        self.serial_device
+            .write_all(&self.buffer)
+            .map_err(SerialPublishError::IOError)?;
+
+        Ok(())
+    }
+}
+
+/// Serial Subscriber that reads data from a serial line
+///
+/// Note: To make this subscriber no_std compatible the subscriber
+/// has an internal buffer that is statically allocated, hence the reason
+/// for the const BUFFER_SIZE: usize generic
+pub struct SerialSubscriber<
+    Data: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err>,
+    Err: Error,
+    const BUFFER_SIZE: usize,
+> {
+    /// The serial peripheral device
+    serial_device: Serial,
+    /// The internal buffer for decoding data
+    buffer: [u8; BUFFER_SIZE],
+    /// The current data stored in the subscriber
+    data: Option<Data>,
+}
+
+impl<Data, Serial, Err, const BUFFER_SIZE: usize> SerialSubscriber<Data, Serial, Err, BUFFER_SIZE>
+where
+    Data: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err>,
+    Err: Error,
+{
+    /// Create a new SerialSubscriber from the peripheral
+    pub fn new(serial_device: Serial, buffer: [u8; BUFFER_SIZE]) -> Self {
+        assert!(
+            BUFFER_SIZE >= Data::len(),
+            "The buffer must be large enough to fit encoded data"
+        );
+        Self {
+            serial_device,
+            buffer,
+            data: None,
+        }
+    }
+
+    /// Destroy the SerialSubscriber returning the serial peripheral
+    pub fn destroy(self) -> Serial {
+        self.serial_device
+    }
+}
+
+impl<Data, Serial, Err, const BUFFER_SIZE: usize> Subscriber
+    for SerialSubscriber<Data, Serial, Err, BUFFER_SIZE>
+where
+    Data: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err>,
+    Err: Error,
+{
+    type Target = Option<Data>;
+
+    fn get(&mut self) -> &Self::Target {
+        let mut new_data = None;
+
+        while let Ok(ready) = self.serial_device.read_ready() {
+            if !ready {
+                break;
+            }
+
+            self.buffer.iter_mut().for_each(|v| *v = 0);
+            if self.serial_device.read(&mut self.buffer).is_ok() {
+                if let Ok(data) = Data::unpack(&self.buffer) {
+                    new_data = Some(data);
+                }
+            }
+        }
+
+        if let Some(data) = new_data {
+            self.data = Some(data);
+        }
+
+        &self.data
+    }
+}
+
+/// A serial publisher/subscriber capable of both publishing and subscribing
+/// a specific data type.
+///
+/// Note: To make this subscriber no_std compatible the subscriber
+/// has an internal buffer that is statically allocated, hence the reason
+/// for the const BUFFER_SIZE: usize generic
+pub struct SerialPublisherSubscriber<
+    Data: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err> + Write<Error = Err>,
+    Err: Error,
+    const BUFFER_SIZE: usize,
+> {
+    /// The serial peripheral device
+    serial_device: Serial,
+    /// The internal buffer for sending and receiving data
+    buffer: [u8; BUFFER_SIZE],
+    /// The most recent data received from the subscription
+    data: Option<Data>,
+}
+
+impl<Data, Serial, Err, const BUFFER_SIZE: usize>
+    SerialPublisherSubscriber<Data, Serial, Err, BUFFER_SIZE>
+where
+    Data: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err> + Write<Error = Err>,
+    Err: Error,
+{
+    /// Create a new SerialPublisherSubscriber from the peripheral
+    pub fn new(serial_device: Serial, buffer: [u8; BUFFER_SIZE]) -> Self {
+        assert!(
+            BUFFER_SIZE >= Data::len(),
+            "The buffer must be large enough to fit encoded data"
+        );
+        Self {
+            serial_device,
+            buffer,
+            data: None,
+        }
+    }
+
+    /// Destroy the SerialPublisherSubscriber returning the serial
+    /// peripheral
+    pub fn destroy(self) -> Serial {
+        self.serial_device
+    }
+}
+
+impl<Data, Serial, Err, const BUFFER_SIZE: usize> Publisher
+    for SerialPublisherSubscriber<Data, Serial, Err, BUFFER_SIZE>
+where
+    Data: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err> + Write<Error = Err>,
+    Err: Error,
+{
+    type Data = Data;
+    type Error = SerialPublishError<Err>;
+
+    fn publish(&mut self, data: Self::Data) -> Result<(), Self::Error> {
+        self.buffer.iter_mut().for_each(|v| *v = 0);
+        data.pack(&mut self.buffer)
+            .map_err(SerialPublishError::PackingError)?;
+
+        self.serial_device
+            .write_all(&self.buffer)
+            .map_err(SerialPublishError::IOError)?;
+
+        Ok(())
+    }
+}
+
+impl<Data, Serial, Err, const BUFFER_SIZE: usize> Subscriber
+    for SerialPublisherSubscriber<Data, Serial, Err, BUFFER_SIZE>
+where
+    Data: Packable,
+    Serial: ReadReady<Error = Err> + Read<Error = Err> + Write<Error = Err>,
+    Err: Error,
+{
+    type Target = Option<Data>;
+
+    fn get(&mut self) -> &Self::Target {
+        let mut new_data = None;
+
+        while let Ok(ready) = self.serial_device.read_ready() {
+            if !ready {
+                break;
+            }
+
+            self.buffer.iter_mut().for_each(|v| *v = 0);
+            if self.serial_device.read(&mut self.buffer).is_ok() {
+                if let Ok(data) = Data::unpack(&self.buffer) {
+                    new_data = Some(data);
+                }
+            }
+        }
+
+        if let Some(data) = new_data {
+            self.data = Some(data);
+        }
+
+        &self.data
+    }
+}

--- a/ncomm-update-clients-and-servers/Cargo.toml
+++ b/ncomm-update-clients-and-servers/Cargo.toml
@@ -11,9 +11,16 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-crossbeam = { workspace = true }
-ncomm-core = { workspace = true }
-ncomm-utils = { workspace = true }
+crossbeam = { workspace = true, optional = true }
+ncomm-core = { workspace = true, default-features = false }
+ncomm-utils = { workspace = true, default-features = false }
+embedded-io = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+
+[features]
+default = ["std"]
+nostd = ["ncomm-core/nostd", "ncomm-utils/nostd"]
+alloc = ["nostd", "ncomm-core/alloc", "ncomm-utils/alloc"]
+std = ["ncomm-core/std", "ncomm-utils/std", "dep:crossbeam"]

--- a/ncomm-update-clients-and-servers/src/lib.rs
+++ b/ncomm-update-clients-and-servers/src/lib.rs
@@ -7,6 +7,9 @@
 //!
 
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub mod local;
 

--- a/ncomm-utils/Cargo.toml
+++ b/ncomm-utils/Cargo.toml
@@ -15,4 +15,5 @@ repository.workspace = true
 [features]
 default = ["std"]
 nostd = []
+alloc = []
 std = []

--- a/ncomm-utils/src/lib.rs
+++ b/ncomm-utils/src/lib.rs
@@ -6,7 +6,9 @@
 //! are still useful for developing applications utilizing NComm.
 //!
 
-#![no_std]
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub mod packing;

--- a/ncomm/Cargo.toml
+++ b/ncomm/Cargo.toml
@@ -12,15 +12,43 @@ authors.workspace = true
 categories.workspace = true
 
 [dependencies]
-ncomm-core = { workspace = true }
-ncomm-utils = { workspace = true }
-ncomm-executors = { workspace = true }
-ncomm-publishers-and-subscribers = { workspace = true }
-ncomm-clients-and-servers = { workspace = true }
-ncomm-update-clients-and-servers = { workspace = true }
-ncomm-nodes = { workspace = true }
+ncomm-core = { workspace = true, default-features = false }
+ncomm-utils = { workspace = true, default-features = false }
+ncomm-executors = { workspace = true, default-features = false }
+ncomm-publishers-and-subscribers = { workspace = true, default-features = false }
+ncomm-clients-and-servers = { workspace = true, default-features = false }
+ncomm-update-clients-and-servers = { workspace = true, default-features = false }
+ncomm-nodes = { workspace = true, default-features = false }
 
 [features]
 default = []
-rerun = ["ncomm-nodes/rerun", "ncomm-publishers-and-subscribers/rerun"]
-rerun-web-viewer = ["rerun", "ncomm-nodes/rerun-web-viewer"]
+nostd = [
+    "ncomm-core/nostd",
+    "ncomm-utils/nostd",
+    "ncomm-executors/nostd",
+    "ncomm-publishers-and-subscribers/nostd",
+    "ncomm-clients-and-servers/nostd",
+    "ncomm-update-clients-and-servers/nostd",
+    "ncomm-nodes/nostd",
+]
+alloc = [
+    "nostd",
+    "ncomm-core/alloc",
+    "ncomm-utils/alloc",
+    "ncomm-executors/alloc",
+    "ncomm-publishers-and-subscribers/alloc",
+    "ncomm-clients-and-servers/alloc",
+    "ncomm-update-clients-and-servers/alloc",
+    "ncomm-nodes/alloc",
+]
+std = [
+    "ncomm-core/std",
+    "ncomm-utils/std",
+    "ncomm-executors/std",
+    "ncomm-publishers-and-subscribers/std",
+    "ncomm-clients-and-servers/std",
+    "ncomm-update-clients-and-servers/std",
+    "ncomm-nodes/std",
+]
+rerun = ["std", "ncomm-nodes/rerun", "ncomm-publishers-and-subscribers/rerun"]
+rerun-web-viewer = ["std", "rerun", "ncomm-nodes/rerun-web-viewer"]

--- a/ncomm/src/lib.rs
+++ b/ncomm/src/lib.rs
@@ -70,6 +70,10 @@
 //! Currently, NComm is only available on Rust with the `std` toolchain.  This is fine, but I would love to have `no_std` versions of the communication primitives for embedded development.  However, I don't think it is likely I will make `no_std` executors and instead work on adding communication primitive support to current RTOS's like RTIC and Embassy (both of which much better than I could likely create on my own).  In general, I would encourage people to add anything they think is missing to this project.  I can already see a possibility for building secure network communication primitives and creating standard nodes for data visualization and logging so I encourage people to build whatever they see fit.
 //!
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 pub mod prelude;
 
 /// NComm Clients and Servers


### PR DESCRIPTION
I would like to be able to utilize NComm in no-std, alloc, and std contexts within Rust.  Therefore, while adding support for a serial publisher + subscriber and client + server I figured it would make sense to also add the feature flags "nostd", "alloc", and "std" so that certain parts of the API can be exposed depending on the target.