### PR TITLE
Fix Feature Flags in NComm-Core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "minimal-client-server"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam",
  "ctrlc",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "minimal-publisher-subscriber"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam",
  "ctrlc",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "minimal-update-client-server"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam",
  "ctrlc",
@@ -2819,7 +2819,7 @@ checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
 name = "ncomm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ncomm-clients-and-servers",
  "ncomm-core",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm-clients-and-servers"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam",
  "embedded-io",
@@ -2843,11 +2843,11 @@ dependencies = [
 
 [[package]]
 name = "ncomm-core"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "ncomm-executors"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam",
  "ncomm-core",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm-nodes"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ncomm-core",
  "ncomm-publishers-and-subscribers",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm-publishers-and-subscribers"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam",
  "embedded-io",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm-update-clients-and-servers"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam",
  "embedded-io",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm-utils"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "ndarray"
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "rerun-publisher"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "MIT"
 description = "Rust Node-Based Communication Prototype Framework"
@@ -40,14 +40,14 @@ categories = ["science::robotics"]
 
 [workspace.dependencies]
 # NComm
-ncomm = { path = "ncomm", version = "1.1.0", default-features = false }
-ncomm-core = { path = "ncomm-core", version = "1.1.0", default-features = false }
-ncomm-utils = { path = "ncomm-utils", version = "1.1.0", default-features = false }
-ncomm-executors = { path = "ncomm-executors", version = "1.1.0", default-features = false }
-ncomm-publishers-and-subscribers = { path = "ncomm-publishers-and-subscribers", version = "1.1.0", default-features = false }
-ncomm-clients-and-servers = { path = "ncomm-clients-and-servers", version = "1.1.0", default-features = false }
-ncomm-update-clients-and-servers = { path = "ncomm-update-clients-and-servers", version = "1.1.0", default-features = false }
-ncomm-nodes = { path = "ncomm-nodes", version = "1.0.0", default-features = false }
+ncomm = { path = "ncomm", version = "1.1.1", default-features = false }
+ncomm-core = { path = "ncomm-core", version = "1.1.1", default-features = false }
+ncomm-utils = { path = "ncomm-utils", version = "1.1.1", default-features = false }
+ncomm-executors = { path = "ncomm-executors", version = "1.1.1", default-features = false }
+ncomm-publishers-and-subscribers = { path = "ncomm-publishers-and-subscribers", version = "1.1.1", default-features = false }
+ncomm-clients-and-servers = { path = "ncomm-clients-and-servers", version = "1.1.1", default-features = false }
+ncomm-update-clients-and-servers = { path = "ncomm-update-clients-and-servers", version = "1.1.1", default-features = false }
+ncomm-nodes = { path = "ncomm-nodes", version = "1.1.1", default-features = false }
 
 # Outside Dependencies
 crossbeam = "0.8.4"

--- a/ncomm-core/src/update_client_server.rs
+++ b/ncomm-core/src/update_client_server.rs
@@ -78,6 +78,7 @@ pub trait UpdateServer {
         update: Self::Update,
     ) -> Result<(), Self::Error>;
 
+    #[cfg(any(feature = "alloc", feature = "std"))]
     /// Send a collection of updates to specified client
     #[allow(clippy::type_complexity)]
     fn send_updates(
@@ -98,6 +99,7 @@ pub trait UpdateServer {
         response: Self::Response,
     ) -> Result<(), Self::Error>;
 
+    #[cfg(any(feature = "alloc", feature = "std"))]
     /// Send a collection of responses to specific clients
     #[allow(clippy::type_complexity)]
     fn send_responses(


### PR DESCRIPTION
I missed one of the places Vec was mentioned so when I attempted to publish NComm 1.1.0 the publish compiler caught my error.  This PR fixes this so I will be yanking version 1.1.0 in favor of 1.1.1.