### PR TITLE
Add missed feature flags (pt. 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "minimal-client-server"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "crossbeam",
  "ctrlc",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "minimal-publisher-subscriber"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "crossbeam",
  "ctrlc",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "minimal-update-client-server"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "crossbeam",
  "ctrlc",
@@ -2819,7 +2819,7 @@ checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
 name = "ncomm"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "ncomm-clients-and-servers",
  "ncomm-core",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm-clients-and-servers"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "crossbeam",
  "embedded-io",
@@ -2843,11 +2843,11 @@ dependencies = [
 
 [[package]]
 name = "ncomm-core"
-version = "1.1.1"
+version = "1.1.2"
 
 [[package]]
 name = "ncomm-executors"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "crossbeam",
  "ncomm-core",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm-nodes"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "ncomm-core",
  "ncomm-publishers-and-subscribers",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm-publishers-and-subscribers"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "crossbeam",
  "embedded-io",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm-update-clients-and-servers"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "crossbeam",
  "embedded-io",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ncomm-utils"
-version = "1.1.1"
+version = "1.1.2"
 
 [[package]]
 name = "ndarray"
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "rerun-publisher"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "crossbeam",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license = "MIT"
 description = "Rust Node-Based Communication Prototype Framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,14 @@ categories = ["science::robotics"]
 
 [workspace.dependencies]
 # NComm
-ncomm = { path = "ncomm", version = "1.1.1", default-features = false }
-ncomm-core = { path = "ncomm-core", version = "1.1.1", default-features = false }
-ncomm-utils = { path = "ncomm-utils", version = "1.1.1", default-features = false }
-ncomm-executors = { path = "ncomm-executors", version = "1.1.1", default-features = false }
-ncomm-publishers-and-subscribers = { path = "ncomm-publishers-and-subscribers", version = "1.1.1", default-features = false }
-ncomm-clients-and-servers = { path = "ncomm-clients-and-servers", version = "1.1.1", default-features = false }
-ncomm-update-clients-and-servers = { path = "ncomm-update-clients-and-servers", version = "1.1.1", default-features = false }
-ncomm-nodes = { path = "ncomm-nodes", version = "1.1.1", default-features = false }
+ncomm = { path = "ncomm", version = "1.1.2", default-features = false }
+ncomm-core = { path = "ncomm-core", version = "1.1.2", default-features = false }
+ncomm-utils = { path = "ncomm-utils", version = "1.1.2", default-features = false }
+ncomm-executors = { path = "ncomm-executors", version = "1.1.2", default-features = false }
+ncomm-publishers-and-subscribers = { path = "ncomm-publishers-and-subscribers", version = "1.1.2", default-features = false }
+ncomm-clients-and-servers = { path = "ncomm-clients-and-servers", version = "1.1.2", default-features = false }
+ncomm-update-clients-and-servers = { path = "ncomm-update-clients-and-servers", version = "1.1.2", default-features = false }
+ncomm-nodes = { path = "ncomm-nodes", version = "1.1.2", default-features = false }
 
 # Outside Dependencies
 crossbeam = "0.8.4"

--- a/ncomm-clients-and-servers/src/serial.rs
+++ b/ncomm-clients-and-servers/src/serial.rs
@@ -10,10 +10,10 @@ use embedded_io::{Error, Read, ReadReady, Write};
 use ncomm_core::client_server::{Client, Server};
 use ncomm_utils::packing::{Packable, PackingError};
 
-#[cfg(feature = "std")]
-use std::vec::Vec;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 /// An Error regarding sending and receiving data via serial
 #[derive(Debug)]

--- a/ncomm-clients-and-servers/src/serial.rs
+++ b/ncomm-clients-and-servers/src/serial.rs
@@ -10,6 +10,11 @@ use embedded_io::{Error, Read, ReadReady, Write};
 use ncomm_core::client_server::{Client, Server};
 use ncomm_utils::packing::{Packable, PackingError};
 
+#[cfg(feature = "std")]
+use std::vec::Vec;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 /// An Error regarding sending and receiving data via serial
 #[derive(Debug)]
 pub enum SerialClientServerError<Err: Error> {

--- a/ncomm-publishers-and-subscribers/src/lib.rs
+++ b/ncomm-publishers-and-subscribers/src/lib.rs
@@ -17,6 +17,7 @@ pub mod local;
 #[cfg(feature = "std")]
 pub mod udp;
 
+#[cfg(feature = "std")]
 pub mod tcp;
 
 #[cfg(feature = "rerun")]

--- a/ncomm-update-clients-and-servers/src/lib.rs
+++ b/ncomm-update-clients-and-servers/src/lib.rs
@@ -11,6 +11,8 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "std")]
 pub mod local;
 
+#[cfg(feature = "std")]
 pub mod udp;


### PR DESCRIPTION
I missed another set of feature flags in the pubsubs and update-client-servers, which prevented the crates from being usable in no_std environments.